### PR TITLE
Continue waiting for history data if there is an empty response data …

### DIFF
--- a/dcos_test_utils/dcos_api.py
+++ b/dcos_test_utils/dcos_api.py
@@ -260,9 +260,8 @@ class DcosApiSession(ARNodeApiClientMixin, RetryCommonHttpErrorsMixin, ApiClient
         # resp_code >= 500 -> backend is still down probably
         if ro.status_code <= 500:
             json = ro.json()
-            # We have observed cases of the returned JSON being empty.
+            # We have observed cases of the returned JSON being '{}'.
             if 'slaves' in json:
-                log.info("DC/OS History is probably getting data")
                 # if an agent was removed, it may linger in the history data
                 assert len(json["slaves"]) >= len(self.all_slaves)
                 return True


### PR DESCRIPTION
…structure.

See https://jira.mesosphere.com/browse/DCOS_OSS-1547 for the problem that this works around showing up once in DC/OS OSS tests.

See https://jira.mesosphere.com/browse/DCOS-18971 for it showing up quite reliably in a branch of Enterprise DC/OS.

I made this change as an experiment to see if it would fix the issue described in https://jira.mesosphere.com/browse/DCOS-18971. It does!

However, that was without research into DC/OS History.
Does this look like a bug in DC/OS History? If so, I can create an issue and link to that issue here.
I'm also very open to suggestions of how else to approach this - this was just reactionary to the symptoms I saw.