### PR TITLE
Adding LC_ALL & LANG to dcos_cli environment.

### DIFF
--- a/dcos_test_utils/dcos_cli.py
+++ b/dcos_test_utils/dcos_cli.py
@@ -23,7 +23,9 @@ class DcosCli():
                 os.path.dirname(self.path),
                 os.environ['PATH']),
             'PYTHONIOENCODING': 'utf-8',
-            'PYTHONUNBUFFERED': 'x'
+            'PYTHONUNBUFFERED': 'x',
+            'LC_ALL': 'utf-8',
+            'LANG': 'utf-8'
         })
         self.env = updated_env
 

--- a/dcos_test_utils/dcos_cli.py
+++ b/dcos_test_utils/dcos_cli.py
@@ -27,15 +27,10 @@ class DcosCli():
             'PYTHONUNBUFFERED': 'x',
         })
 
-        if 'LC_ALL' not in updated_env:
-            if 'coreos' in platform.platform():
-                updated_env.update({
-                    'LC_ALL': 'C.UTF-8'
-                })
-            else:
-                updated_env.update({
-                    'LC_ALL': 'en_US.UTF-8'
-                })
+        if 'coreos' in platform.platform():
+            updated_env.update({
+                'LC_ALL': 'C.UTF-8'
+            })
 
         if 'LANG' not in updated_env:
             updated_env.update({

--- a/dcos_test_utils/dcos_cli.py
+++ b/dcos_test_utils/dcos_cli.py
@@ -24,8 +24,8 @@ class DcosCli():
                 os.environ['PATH']),
             'PYTHONIOENCODING': 'utf-8',
             'PYTHONUNBUFFERED': 'x',
-            'LC_ALL': 'C.UTF-8',
-            'LANG': 'C.UTF-8'
+            'LC_ALL': 'en_US.UTF-8',
+            'LANG': 'en_US.UTF-8'
         })
         self.env = updated_env
 

--- a/dcos_test_utils/dcos_cli.py
+++ b/dcos_test_utils/dcos_cli.py
@@ -24,8 +24,8 @@ class DcosCli():
                 os.environ['PATH']),
             'PYTHONIOENCODING': 'utf-8',
             'PYTHONUNBUFFERED': 'x',
-            'LC_ALL': 'utf-8',
-            'LANG': 'utf-8'
+            'LC_ALL': 'C.UTF-8',
+            'LANG': 'C.UTF-8'
         })
         self.env = updated_env
 

--- a/dcos_test_utils/dcos_cli.py
+++ b/dcos_test_utils/dcos_cli.py
@@ -1,5 +1,6 @@
 import logging
 import os
+import platform
 import shutil
 import stat
 import subprocess
@@ -27,9 +28,14 @@ class DcosCli():
         })
 
         if 'LC_ALL' not in updated_env:
-            updated_env.update({
-                'LC_ALL': 'C.UTF-8'
-            })
+            if 'coreos' in platform.platform():
+                updated_env.update({
+                    'LC_ALL': 'C.UTF-8'
+                })
+            else:
+                updated_env.update({
+                    'LC_ALL': 'en_US.UTF-8'
+                })
 
         if 'LANG' not in updated_env:
             updated_env.update({

--- a/dcos_test_utils/dcos_cli.py
+++ b/dcos_test_utils/dcos_cli.py
@@ -24,9 +24,18 @@ class DcosCli():
                 os.environ['PATH']),
             'PYTHONIOENCODING': 'utf-8',
             'PYTHONUNBUFFERED': 'x',
-            'LC_ALL': 'en_US.UTF-8',
-            'LANG': 'en_US.UTF-8'
         })
+
+        if 'LC_ALL' not in updated_env:
+            updated_env.update({
+                'LC_ALL': 'C.UTF-8'
+            })
+
+        if 'LANG' not in updated_env:
+            updated_env.update({
+                'LANG': 'C.UTF-8'
+            })
+
         self.env = updated_env
 
     @classmethod

--- a/dcos_test_utils/onprem.py
+++ b/dcos_test_utils/onprem.py
@@ -140,7 +140,7 @@ def download_dcos_installer(ssh_client, host, installer_path, download_url):
     try:
         ssh_client.command(host, ['curl', '-fLsSv', '--retry', '20', '-Y', '100000', '-y', '60',
                                   '--create-dirs', '-o', installer_path, download_url])
-    except:
+    except Exception:
         log.exception('Download failed!')
         raise
 


### PR DESCRIPTION
This is to fix the following error when executing a `dcos security` command using dcos_cli:

`Failed to execute script dcos-security\nTraceback (most recent call last):\n  File "dcos-security.py", line 19, in <... your issue by exporting the\nfollowing environment variables:\n\n    export LC_ALL=C.UTF-8\n    export LANG=C.UTF-8\n` 