### PR TITLE
DCOS 19496 - Wait for Marathon up - check for v2/info endpoint

### DIFF
--- a/dcos_test_utils/dcos_api.py
+++ b/dcos_test_utils/dcos_api.py
@@ -191,10 +191,11 @@ class DcosApiSession(ARNodeApiClientMixin, RetryCommonHttpErrorsMixin, ApiClient
                     retry_on_result=lambda ret: ret is False,
                     retry_on_exception=lambda x: False)
     def _wait_for_marathon_up(self):
-        r = self.get('/marathon/ui/')
-        # resp_code >= 500 -> backend is still down probably
-        if r.status_code < 500:
-            log.info("Marathon is probably up")
+        r = self.get('/marathon/v2/info')
+        # http://mesosphere.github.io/marathon/api-console/index.html
+        # 200 at /marathon/v2/info indicates marathon is up.
+        if r.status_code == 200:
+            log.info("Marathon is up.")
             return True
         else:
             msg = "Waiting for Marathon, resp code is: {}"


### PR DESCRIPTION
In the current implementation

```
 r = self.get('/marathon/ui/')
```

Results in 404, and we find it OK because the service is not 500'ing

However, I think, it is better to verify for 

`v2/info` endpoint as [documented by the API ](http://mesosphere.github.io/marathon/api-console/index.html)to be up.

[v2/info endpoint ](https://github.com/mesosphere/marathon/blob/v1.3.0/docs/docs/rest-api/public/api/v2/info.raml )was added in `1.3.0` and it should support our existing pre and post upgrade scenarios of DCOS 1.8+

