### PR TITLE
Adds support for hierarchical roles wildcard '%'

### DIFF
--- a/dcos_test_utils/iam.py
+++ b/dcos_test_utils/iam.py
@@ -48,26 +48,26 @@ class Iam(helpers.ApiClientSession):
                                       'Content {}'.format(r.status_code, r.content.decode()))
 
     def create_user_permission(self, uid, action, rid, description):
-        rid = ridrid.replace('%', '%25').replace('/', '%252F')
+        rid = rid.replace('%', '%25').replace('/', '%252F')
         r = self.put('/acls/{}'.format(rid), json={'description': description})
         assert r.status_code == 201, ('Permission was not created. Code {}. '
                                       'Content {}'.format(r.status_code, r.content.decode()))
 
     def delete_user_permission(self, uid, action, rid):
-        rid = ridrid.replace('%', '%25').replace('/', '%252F')
+        rid = rid.replace('%', '%25').replace('/', '%252F')
         r = self.delete('/acls/{}/users/{}/{}'.format(rid, uid, action))
         assert r.status_code == 204, ('Permission was not deleted. Code {}. '
                                       'Content {}'.format(r.status_code, r.content.decode()))
 
     def create_acl(self, rid, description):
-        rid = ridrid.replace('%', '%25').replace('/', '%252F')
+        rid = rid.replace('%', '%25').replace('/', '%252F')
         # Create ACL if it does not yet exist.
         r = self.put('/acls/{}'.format(rid), json={'description': description})
         assert r.status_code == 201 or r.status_code == 409, ('ACL was not created. Code {}. '
                                       'Content {}'.format(r.status_code, r.content.decode()))
 
     def delete_acl(self, rid):
-        rid = ridrid.replace('%', '%25').replace('/', '%252F')
+        rid = rid.replace('%', '%25').replace('/', '%252F')
         r = self.delete('/acls/{}'.format(rid))
         assert r.status_code == 204, ('Permission was not deleted. Code {}. '
                                       'Content {}'.format(r.status_code, r.content.decode()))

--- a/dcos_test_utils/iam.py
+++ b/dcos_test_utils/iam.py
@@ -20,7 +20,7 @@ class Iam(helpers.ApiClientSession):
             'public_key': pubkey
         }
         r = self.put('/users/{}'.format(uid), json=data)
-        assert r.status_code == 201, ('Service not crreated. Code: {}. '
+        assert r.status_code == 201, ('Service not created. Code: {}. '
                                       'Content {}'.format(r.status_code, r.text))
 
     def delete_service(self, uid: str) -> None:
@@ -32,13 +32,13 @@ class Iam(helpers.ApiClientSession):
         Raises:
             AssertionError: The delete operation does not succeed.
         """
-        resp = self.delete('/users/{}'.format(uid))
-        assert resp.status_code == 204, ('Service not deleted. Code: {}. '
-                                         'Content {}'.format(resp.status_code, resp.text))
+        r = self.delete('/users/{}'.format(uid))
+        assert r.status_code == 204, ('Service not deleted. Code: {}. '
+                                      'Content {}'.format(r.status_code, r.text))
 
         # Verify that service does not appear in collection anymore.
-        resp = self.get('/users', query='type=service')
-        uids = [account['uid'] for account in resp.json()['array']]
+        r = self.get('/users', query='type=service')
+        uids = [account['uid'] for account in r.json()['array']]
         assert uid not in uids
 
     def grant_user_permission(self, uid, action, rid):

--- a/dcos_test_utils/iam.py
+++ b/dcos_test_utils/iam.py
@@ -20,7 +20,8 @@ class Iam(helpers.ApiClientSession):
             'public_key': pubkey
         }
         r = self.put('/users/{}'.format(uid), json=data)
-        assert r.status_code == 201
+        assert r.status_code == 201, ('Service not crreated. Code: {}. '
+                                      'Content {}'.format(r.status_code, r.text))
 
     def delete_service(self, uid: str) -> None:
         """Delete a service account and verify that this worked.
@@ -32,7 +33,8 @@ class Iam(helpers.ApiClientSession):
             AssertionError: The delete operation does not succeed.
         """
         resp = self.delete('/users/{}'.format(uid))
-        assert resp.status_code == 204
+        assert resp.status_code == 204, ('Service not deleted. Code: {}. '
+                                         'Content {}'.format(r.status_code, r.text))
 
         # Verify that service does not appear in collection anymore.
         resp = self.get('/users', query='type=service')
@@ -54,18 +56,21 @@ class Iam(helpers.ApiClientSession):
     def delete_user_permission(self, uid, action, rid):
         rid = ridrid.replace('%', '%25').replace('/', '%252F')
         r = self.delete('/acls/{}/users/{}/{}'.format(rid, uid, action))
-        assert r.status_code == 204
+        assert r.status_code == 204, ('Permission was not deleted. Code {}. '
+                                      'Content {}'.format(r.status_code, r.content.decode()))
 
     def create_acl(self, rid, description):
         rid = ridrid.replace('%', '%25').replace('/', '%252F')
         # Create ACL if it does not yet exist.
         r = self.put('/acls/{}'.format(rid), json={'description': description})
-        assert r.status_code == 201 or r.status_code == 409
+        assert r.status_code == 201 or r.status_code == 409, ('ACL was not created. Code {}. '
+                                      'Content {}'.format(r.status_code, r.content.decode()))
 
     def delete_acl(self, rid):
         rid = ridrid.replace('%', '%25').replace('/', '%252F')
         r = self.delete('/acls/{}'.format(rid))
-        assert r.status_code == 204
+        assert r.status_code == 204, ('Permission was not deleted. Code {}. '
+                                      'Content {}'.format(r.status_code, r.content.decode()))
 
     def make_service_account_credentials(self, uid, privkey):
         return {

--- a/dcos_test_utils/iam.py
+++ b/dcos_test_utils/iam.py
@@ -34,7 +34,7 @@ class Iam(helpers.ApiClientSession):
         """
         resp = self.delete('/users/{}'.format(uid))
         assert resp.status_code == 204, ('Service not deleted. Code: {}. '
-                                         'Content {}'.format(r.status_code, r.text))
+                                         'Content {}'.format(resp.status_code, resp.text))
 
         # Verify that service does not appear in collection anymore.
         resp = self.get('/users', query='type=service')
@@ -63,8 +63,9 @@ class Iam(helpers.ApiClientSession):
         rid = rid.replace('%', '%25').replace('/', '%252F')
         # Create ACL if it does not yet exist.
         r = self.put('/acls/{}'.format(rid), json={'description': description})
-        assert r.status_code == 201 or r.status_code == 409, ('ACL was not created. Code {}. '
-                                      'Content {}'.format(r.status_code, r.content.decode()))
+        assert r.status_code == 201 or r.status_code == 409, \
+            ('ACL was not created. Code {}. '
+             'Content {}'.format(r.status_code, r.content.decode()))
 
     def delete_acl(self, rid):
         rid = rid.replace('%', '%25').replace('/', '%252F')

--- a/dcos_test_utils/iam.py
+++ b/dcos_test_utils/iam.py
@@ -40,30 +40,30 @@ class Iam(helpers.ApiClientSession):
         assert uid not in uids
 
     def grant_user_permission(self, uid, action, rid):
-        rid = rid.replace('/', '%252F')
+        rid = rid.replace('%', '%25').replace('/', '%252F')
         r = self.put('/acls/{}/users/{}/{}'.format(rid, uid, action))
         assert r.status_code == 204, ('Permission was not granted. Code: {}. '
                                       'Content {}'.format(r.status_code, r.content.decode()))
 
     def create_user_permission(self, uid, action, rid, description):
-        rid = rid.replace('/', '%252F')
+        rid = ridrid.replace('%', '%25').replace('/', '%252F')
         r = self.put('/acls/{}'.format(rid), json={'description': description})
         assert r.status_code == 201, ('Permission was not created. Code {}. '
                                       'Content {}'.format(r.status_code, r.content.decode()))
 
     def delete_user_permission(self, uid, action, rid):
-        rid = rid.replace('/', '%252F')
+        rid = ridrid.replace('%', '%25').replace('/', '%252F')
         r = self.delete('/acls/{}/users/{}/{}'.format(rid, uid, action))
         assert r.status_code == 204
 
     def create_acl(self, rid, description):
-        rid = rid.replace('/', '%252F')
+        rid = ridrid.replace('%', '%25').replace('/', '%252F')
         # Create ACL if it does not yet exist.
         r = self.put('/acls/{}'.format(rid), json={'description': description})
         assert r.status_code == 201 or r.status_code == 409
 
     def delete_acl(self, rid):
-        rid = rid.replace('/', '%252F')
+        rid = ridrid.replace('%', '%25').replace('/', '%252F')
         r = self.delete('/acls/{}'.format(rid))
         assert r.status_code == 204
 


### PR DESCRIPTION
Hierarchical roles in Mesos use the character `%` as a wildcard to grant permissions to sub roles. This requires IAM abstraction to also encode the character when communicating with Bouncer.

In order to verify the encoded of `%` is correct, I ran the following script:

```py
import urllib.parse

print(urllib.parse.urlencode({'test':'%'})) # yields: 'test=%25'
```