### PR TITLE
raise_for_status on responses before trying to extract json

### DIFF
--- a/dcos_test_utils/enterprise.py
+++ b/dcos_test_utils/enterprise.py
@@ -76,5 +76,6 @@ class EnterpriseApiSession(MesosNodeClientMixin, dcos_api.DcosApiSession):
     def set_initial_resource_ids(self):
         self.initial_resource_ids = []
         r = self.iam.get('/acls')
+        r.raise_for_status()
         for o in r.json()['array']:
             self.initial_resource_ids.append(o['rid'])

--- a/dcos_test_utils/iam.py
+++ b/dcos_test_utils/iam.py
@@ -36,6 +36,7 @@ class Iam(helpers.ApiClientSession):
 
         # Verify that service does not appear in collection anymore.
         resp = self.get('/users', query='type=service')
+        resp.raise_for_status()
         uids = [account['uid'] for account in resp.json()['array']]
         assert uid not in uids
 

--- a/dcos_test_utils/marathon.py
+++ b/dcos_test_utils/marathon.py
@@ -283,10 +283,14 @@ class Marathon(RetryCommonHttpErrorsMixin, ApiClientSession):
         """ Force deletes all applications, all pods, and then waits
         indefinitely for any deployments to finish
         """
-        for app in self.get('v2/apps').json()['apps']:
+        apps_response = self.get('v2/apps')
+        apps_response.raise_for_status()
+        for app in apps_response.json()['apps']:
             log.info('Purging application: {}'.format(app['id']))
             self.delete('v2/apps' + app['id'], params=FORCE_PARAMS)
-        for pod in self.get('v2/pods').json():
+        pods_response = self.get('v2/pods')
+        pods_response.raise_for_status()
+        for pod in pods_response.json():
             log.info('Deleting pod: {}'.format(pod['id']))
             self.delete('v2/pods' + pod['id'], params=FORCE_PARAMS)
         self.wait_for_deployments_complete()


### PR DESCRIPTION
Use `raise_for_status` to get slightly better error messages than
```
s = '404 Not Found: service not found.\n'
...
json.decoder.JSONDecodeError: Extra data: line 1 column 5 (char 4)
```
https://jira.mesosphere.com/browse/QUALITY-1614