### PR TITLE
Refactor SshClient to use SCP for copying

### DIFF
--- a/dcos_test_utils/ssh_client.py
+++ b/dcos_test_utils/ssh_client.py
@@ -27,7 +27,8 @@ SHARED_SSH_OPTS = [
 
 class Tunnelled():
     def __init__(self, opt_list: list, target: str, port: int):
-        """
+        """ Abstraction of an already instantiated SSH-tunnel
+
         Args:
             opt_list: list of SSH options strings. E.G. '-oControlPath=foo'
             target: string in the form user@host
@@ -38,7 +39,9 @@ class Tunnelled():
         self.port = port
 
     def command(self, cmd: list, **kwargs) -> bytes:
-        """ Run a command at the tunnel target Args:
+        """ Run a command at the tunnel target
+
+        Args:
             cmd: list of strings that will be sent as a command to the target
             **kwargs: any keywork args that can be passed into
                 subprocess.check_output. For more information, see:

--- a/dcos_test_utils/test_ssh_client.py
+++ b/dcos_test_utils/test_ssh_client.py
@@ -90,7 +90,7 @@ def tunnel_args(sshd_manager, tmpdir):
     with sshd_manager.run(1) as sshd_ports:
         yield {
             'user': getpass.getuser(),
-            'control_path': str(tmpdir.join('control_path')),
+            'control_path': str(tmpdir.join('x')),  # use as short a name as possible
             'key_path': helpers.session_tempfile(sshd_manager.key),
             'host': '127.0.0.1',
             'port': sshd_ports[0]}


### PR DESCRIPTION
  Previously this used `cat` though SSH to avoid having to reformat the SSH command to use a tunnel in the case of SCP where `-P` is used instead of `-p`