### PR TITLE
Ensure apps or pods are deleted after failure

### DIFF
--- a/dcos_test_utils/marathon.py
+++ b/dcos_test_utils/marathon.py
@@ -270,14 +270,18 @@ class Marathon(RetryCommonHttpErrorsMixin, ApiClientSession):
 
     @contextlib.contextmanager
     def deploy_and_cleanup(self, app_definition, timeout=1200, check_health=True, ignore_failed_tasks=False):
-        yield self.deploy_app(
-            app_definition, check_health, ignore_failed_tasks, timeout=timeout)
-        self.destroy_app(app_definition['id'], timeout)
+        try:
+            yield self.deploy_app(
+                app_definition, check_health, ignore_failed_tasks, timeout=timeout)
+        finally:
+            self.destroy_app(app_definition['id'], timeout)
 
     @contextlib.contextmanager
     def deploy_pod_and_cleanup(self, pod_definition, timeout=1200):
-        yield self.deploy_pod(pod_definition, timeout=timeout)
-        self.destroy_pod(pod_definition['id'], timeout)
+        try:
+            yield self.deploy_pod(pod_definition, timeout=timeout)
+        finally:
+            self.destroy_pod(pod_definition['id'], timeout)
 
     def purge(self):
         """ Force deletes all applications, all pods, and then waits

--- a/tox.ini
+++ b/tox.ini
@@ -16,6 +16,7 @@ testpaths =
 [testenv]
 deps =
   -rrequirements.txt
+  teamcity-messages
 
 [testenv:py35-syntax]
 passenv = TEAMCITY_VERSION


### PR DESCRIPTION
If an exception is raised in a code block with these context managers, the apps will live on forever