### PR TITLE
Allow dampening optional modules

### DIFF
--- a/dcos_test_utils/logger.py
+++ b/dcos_test_utils/logger.py
@@ -14,7 +14,13 @@ MODULE_BROWN_LIST = [
     'boto3']
 
 
-def setup(log_level_str: str):
+def setup(log_level_str: str, noisy_modules: list=None):
+    """ Handles the builtin python log levels and adds level below
+    debug (trace) which dampened modules will log debug at
+    Args:
+        log_level_str: user-provided string to set the log-level
+        noisy_modules: any additional modules that should have their level increased
+    """
     if log_level_str == 'CRITICAL':
         log_level = logging.CRITICAL
     elif log_level_str == 'ERROR':
@@ -29,7 +35,12 @@ def setup(log_level_str: str):
         raise ValueError('{} is not a valid log level'.format(log_level_str))
     logging.basicConfig(format=LOGGING_FORMAT, level=log_level)
     if log_level_str in ('TRACE', 'CRITICAL'):
+        # trace logging is supposd to show all; no need to raise log level
+        # critical logging is the highest level so its meaningless to raise more
         return
     # now dampen the loud loggers
-    for module in ['botocore', 'boto3']:
+    module_list = MODULE_BROWN_LIST
+    if noisy_modules is not None:
+        module_list.extend(noisy_modules)
+    for module in module_list:
         logging.getLogger(module).setLevel(log_level + 10)


### PR DESCRIPTION
if `noisy_modules` is given, additional modules can have their log-level reduced