### PR TITLE
Consistent Cluster Session Setup

### DIFF
--- a/dcos_test_utils/dcos_api.py
+++ b/dcos_test_utils/dcos_api.py
@@ -88,7 +88,9 @@ class DcosApiSession(helpers.ARNodeApiClientMixin, helpers.RetryCommonHttpErrors
 
     @classmethod
     def create(cls):
-        return cls(**cls.get_args_from_env())
+        api = cls(**cls.get_args_from_env())
+        api._authenticate_default_user()
+        return api
 
     @staticmethod
     def get_args_from_env():

--- a/dcos_test_utils/enterprise.py
+++ b/dcos_test_utils/enterprise.py
@@ -41,6 +41,10 @@ class EnterpriseUser(dcos_api.DcosUser):
 
 
 class EnterpriseApiSession(MesosNodeClientMixin, dcos_api.DcosApiSession):
+    def __init__(self, *args, ssl_enabled=True, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.ssl_enabled = ssl_enabled
+
     @property
     def iam(self):
         return iam.Iam(self.default_url.copy(path='acs/api/v1'), session=self.copy().session)
@@ -56,12 +60,6 @@ class EnterpriseApiSession(MesosNodeClientMixin, dcos_api.DcosApiSession):
         new = self.copy()
         new.default_url = self.default_url.copy(path='ca/api/v2')
         return new
-
-    @classmethod
-    def create(cls):
-        api = cls(**cls.get_args_from_env())
-        api.set_ca_cert()
-        return api
 
     @staticmethod
     def get_args_from_env():
@@ -87,5 +85,7 @@ class EnterpriseApiSession(MesosNodeClientMixin, dcos_api.DcosApiSession):
             self.initial_resource_ids.append(o['rid'])
 
     def wait_for_dcos(self):
+        if self.ssl_enabled:
+            self.set_ca_cert()
         super().wait_for_dcos()
         self.set_initial_resource_ids()

--- a/dcos_test_utils/enterprise.py
+++ b/dcos_test_utils/enterprise.py
@@ -51,6 +51,7 @@ class EnterpriseApiSession(MesosNodeClientMixin, dcos_api.DcosApiSession):
         if api.ssl_enabled:
             api.set_ca_cert()
         api._authenticate_default_user()
+        api.set_initial_resource_ids()
         return api
 
     @property
@@ -97,3 +98,4 @@ class EnterpriseApiSession(MesosNodeClientMixin, dcos_api.DcosApiSession):
         if self.ssl_enabled:
             self.set_ca_cert()
         super().wait_for_dcos()
+        self.set_initial_resource_ids()


### PR DESCRIPTION
Refactors create and wait_for_dcos to provide API sessions in the same state. More specifically, the CA cert and the initial RID cache are both implicitly set in the enterprise session so that there is no difference when using the open session