### PR TITLE
Simplify URL path handing in ApiClientSession

### DIFF
--- a/dcos_test_utils/dcos_api.py
+++ b/dcos_test_utils/dcos_api.py
@@ -352,7 +352,7 @@ class DcosApiSession(helpers.ARNodeApiClientMixin, helpers.RetryCommonHttpErrors
                     retry_on_result=lambda r: r is False,
                     retry_on_exception=lambda _: False)
     def _wait_for_all_healthy_services(self):
-        r = self.health.get('units')
+        r = self.health.get('/units')
         r.raise_for_status()
 
         all_healthy = True
@@ -480,14 +480,14 @@ class DcosApiSession(helpers.ARNodeApiClientMixin, helpers.RetryCommonHttpErrors
             log.info('Metronome one-off successful')
             return True
         log.info('Creating metronome job: ' + repr(job_definition))
-        r = self.metronome.post('jobs', json=job_definition)
+        r = self.metronome.post('/jobs', json=job_definition)
         helpers.assert_response_ok(r)
         log.info('Starting metronome job')
-        r = self.metronome.post('jobs/{}/runs'.format(job_id))
+        r = self.metronome.post('/jobs/{}/runs'.format(job_id))
         helpers.assert_response_ok(r)
         wait_for_completion()
         log.info('Deleting metronome one-off')
-        r = self.metronome.delete('jobs/' + job_id)
+        r = self.metronome.delete('/jobs/' + job_id)
         helpers.assert_response_ok(r)
 
     def mesos_sandbox_directory(self, slave_id, framework_id, task_id):

--- a/dcos_test_utils/diagnostics.py
+++ b/dcos_test_utils/diagnostics.py
@@ -32,7 +32,7 @@ class Diagnostics(ARNodeApiClientMixin, RetryCommonHttpErrorsMixin, ApiClientSes
     def start_diagnostics_job(self, nodes=None):
         if nodes is None:
             nodes = {"nodes": ["all"]}
-        return self.post('report/diagnostics/create', json=nodes)
+        return self.post('/report/diagnostics/create', json=nodes)
 
     @retrying.retry(wait_fixed=2000, stop_max_delay=120000,
                     retry_on_result=lambda x: x is False)
@@ -44,7 +44,7 @@ class Diagnostics(ARNodeApiClientMixin, RetryCommonHttpErrorsMixin, ApiClientSes
             'value': 0
         }
         """
-        session_response = self.get('report/diagnostics/status/all')
+        session_response = self.get('/report/diagnostics/status/all')
         response = check_json(session_response)
         job_running = False
         percent_done = 0
@@ -69,7 +69,7 @@ class Diagnostics(ARNodeApiClientMixin, RetryCommonHttpErrorsMixin, ApiClientSes
         return not job_running
 
     def get_diagnostics_reports(self):
-        response = check_json(self.get('report/diagnostics/list/all'))
+        response = check_json(self.get('/report/diagnostics/list/all'))
 
         def _at_least_one_item(bundle):
             return bundle is not None and isinstance(bundle, list) and len(bundle) > 0
@@ -97,7 +97,7 @@ class Diagnostics(ARNodeApiClientMixin, RetryCommonHttpErrorsMixin, ApiClientSes
         for bundle in diagnostics_bundles:
             log.info('Downloading {}'.format(bundle))
             for master_node in self.masters:
-                r = self.get(os.path.join('report/diagnostics/serve', bundle), stream=True, node=master_node)
+                r = self.get(os.path.join('/report/diagnostics/serve', bundle), stream=True, node=master_node)
                 bundle_path = os.path.join(download_directory, bundle)
                 with open(bundle_path, 'wb') as f:
                     for chunk in r.iter_content(1024):

--- a/dcos_test_utils/enterprise.py
+++ b/dcos_test_utils/enterprise.py
@@ -83,7 +83,7 @@ class EnterpriseApiSession(MesosNodeClientMixin, dcos_api.DcosApiSession):
 
     def set_ca_cert(self):
         log.info('Attempt to get CA bundle via Admin Router')
-        r = self.get('ca/dcos-ca.crt', verify=False)
+        r = self.get('/ca/dcos-ca.crt', verify=False)
         r.raise_for_status()
         self.session.verify = helpers.session_tempfile(r.content)
 

--- a/dcos_test_utils/helpers.py
+++ b/dcos_test_utils/helpers.py
@@ -133,7 +133,7 @@ class ApiClientSession:
             requests.Response
         """
 
-        final_path = path_join(self.default_url.path, path_extension)
+        final_path = self.default_url.path + path_extension
 
         request_url = str(self.default_url.copy(
             scheme=scheme,

--- a/dcos_test_utils/marathon.py
+++ b/dcos_test_utils/marathon.py
@@ -60,7 +60,7 @@ class Marathon(RetryCommonHttpErrorsMixin, ApiClientSession):
                       ('embed', 'apps.counts'))
 
         log.info('Waiting for application to be deployed...')
-        r = self.get(path_join('v2/apps', app_id), params=req_params)
+        r = self.get(path_join('/v2/apps', app_id), params=req_params)
         r.raise_for_status()
 
         data = r.json()
@@ -92,7 +92,7 @@ class Marathon(RetryCommonHttpErrorsMixin, ApiClientSession):
     def get_app_service_endpoints(self, app_id: str) -> typing.List[Endpoint]:
         """ returns endpoint tuples for the given application ID
         """
-        r = self.get(path_join('v2/apps', app_id))
+        r = self.get(path_join('/v2/apps', app_id))
         r.raise_for_status()
         data = r.json()
         res = [Endpoint(t['host'], t['ports'][0], t['ipAddresses'][0]['ipAddress'])
@@ -148,7 +148,7 @@ class Marathon(RetryCommonHttpErrorsMixin, ApiClientSession):
             applications. I.E:
                 [Endpoint(host='172.17.10.202', port=10464), Endpoint(host='172.17.10.201', port=1630)]
         """
-        r = self.post('v2/apps', json=app_definition)
+        r = self.post('/v2/apps', json=app_definition)
         log.info('Response from marathon: {}'.format(repr(r.json())))
         r.raise_for_status()
 
@@ -176,7 +176,7 @@ class Marathon(RetryCommonHttpErrorsMixin, ApiClientSession):
         Returns:
             Pod data JSON
         """
-        r = self.post('v2/pods', json=pod_definition)
+        r = self.post('/v2/pods', json=pod_definition)
         assert r.ok, 'status_code: {} content: {}'.format(r.status_code, r.content)
         log.info('Response from marathon: {}'.format(repr(r.json())))
 
@@ -189,7 +189,7 @@ class Marathon(RetryCommonHttpErrorsMixin, ApiClientSession):
             # if test pod deployments become more complex, we should switch to
             # using Marathon's event bus and listen for specific events.
             # See DCOS_OSS-1056.
-            r = self.get('v2/pods' + pod_id + '::status')
+            r = self.get('/v2/pods' + pod_id + '::status')
             r.raise_for_status()
             data = r.json()
             if 'status' in data and data['status'] == 'STABLE':
@@ -217,7 +217,7 @@ class Marathon(RetryCommonHttpErrorsMixin, ApiClientSession):
                         retry_on_result=lambda ret: not ret,
                         retry_on_exception=lambda x: False)
         def _destroy_pod_complete(deployment_id):
-            r = self.get('v2/deployments')
+            r = self.get('/v2/deployments')
             assert r.ok, 'status_code: {} content: {}'.format(r.status_code, r.content)
 
             for deployment in r.json():
@@ -227,7 +227,7 @@ class Marathon(RetryCommonHttpErrorsMixin, ApiClientSession):
             log.info('Pod destroyed')
             return True
 
-        r = self.delete('v2/pods' + pod_id)
+        r = self.delete('/v2/pods' + pod_id)
         assert r.ok, 'status_code: {} content: {}'.format(r.status_code, r.content)
 
         try:
@@ -249,7 +249,7 @@ class Marathon(RetryCommonHttpErrorsMixin, ApiClientSession):
                         retry_on_result=lambda ret: not ret,
                         retry_on_exception=lambda x: False)
         def _destroy_complete(deployment_id):
-            r = self.get('v2/deployments')
+            r = self.get('/v2/deployments')
             r.raise_for_status()
 
             for deployment in r.json():
@@ -259,7 +259,7 @@ class Marathon(RetryCommonHttpErrorsMixin, ApiClientSession):
             log.info('Application destroyed')
             return True
 
-        r = self.delete(path_join('v2/apps', app_name))
+        r = self.delete(path_join('/v2/apps', app_name))
         r.raise_for_status()
 
         try:
@@ -287,16 +287,16 @@ class Marathon(RetryCommonHttpErrorsMixin, ApiClientSession):
         """ Force deletes all applications, all pods, and then waits
         indefinitely for any deployments to finish
         """
-        apps_response = self.get('v2/apps')
+        apps_response = self.get('/v2/apps')
         apps_response.raise_for_status()
         for app in apps_response.json()['apps']:
             log.info('Purging application: {}'.format(app['id']))
-            self.delete('v2/apps' + app['id'], params=FORCE_PARAMS)
-        pods_response = self.get('v2/pods')
+            self.delete('/v2/apps' + app['id'], params=FORCE_PARAMS)
+        pods_response = self.get('/v2/pods')
         pods_response.raise_for_status()
         for pod in pods_response.json():
             log.info('Deleting pod: {}'.format(pod['id']))
-            self.delete('v2/pods' + pod['id'], params=FORCE_PARAMS)
+            self.delete('/v2/pods' + pod['id'], params=FORCE_PARAMS)
         self.wait_for_deployments_complete()
 
     @retrying.retry(
@@ -304,7 +304,7 @@ class Marathon(RetryCommonHttpErrorsMixin, ApiClientSession):
         retry_on_result=lambda res: res is False,
         retry_on_exception=lambda ex: False)
     def wait_for_deployments_complete(self):
-        if not self.get('v2/deployments').json():
+        if not self.get('/v2/deployments').json():
             return True
         log.info('Deployments in progress, continuing to wait...')
         return False

--- a/dcos_test_utils/package.py
+++ b/dcos_test_utils/package.py
@@ -65,7 +65,7 @@ class Cosmos(RetryCommonHttpErrorsMixin, ApiClientSession):
             package.update({'options': options})
         if app_id is not None:
             package.update({'appId': app_id})
-        return self._post('install', package)
+        return self._post('/install', package)
 
     def uninstall_package(self, package_name, app_id=None):
         """Uninstall a package using the cosmos packaging API
@@ -83,7 +83,7 @@ class Cosmos(RetryCommonHttpErrorsMixin, ApiClientSession):
         }
         if app_id is not None:
             package.update({'appId': app_id})
-        return self._post('uninstall', package)
+        return self._post('/uninstall', package)
 
     def list_packages(self):
         """List all packages using the cosmos packaging API
@@ -92,4 +92,4 @@ class Cosmos(RetryCommonHttpErrorsMixin, ApiClientSession):
             requests.response object
         """
         self._update_headers('list')
-        return self._post('list', {})
+        return self._post('/list', {})

--- a/integration_test.py
+++ b/integration_test.py
@@ -23,7 +23,7 @@ def test_dcos_is_up(dcos_api_session):
     """ Simple test to ensure that this package can authenticate and inspect
     a DC/OS cluster via the pytest-dcos plugin
     """
-    r = dcos_api_session.health.get('units')
+    r = dcos_api_session.health.get('/units')
     r.raise_for_status()
     log.info('Got system health: ' + str(r.json()))
 

--- a/tests/test_dcos_api.py
+++ b/tests/test_dcos_api.py
@@ -4,7 +4,9 @@ DC/OS integration tests, see: packages/dcos-integration-tests/extra
 import pytest
 import requests
 
-from dcos_test_utils import dcos_api
+from unittest.mock import MagicMock
+
+from dcos_test_utils import dcos_api, helpers
 
 
 class MockResponse:
@@ -70,3 +72,25 @@ def test_dcos_client_api(mock_dcos_client):
     cluster.head('')
     cluster.patch('')
     cluster.options('')
+
+
+def test_api_client_session_path(monkeypatch):
+    mock_request = MagicMock()
+    monkeypatch.setattr(requests.Session, 'request', mock_request)
+    access_url = 'http://leader.mesos'
+    api = helpers.ApiClientSession(helpers.Url.from_string(access_url))
+    api.get('')
+    assert mock_request.call_args[0][0] == 'GET'
+    assert mock_request.call_args[0][1] == access_url
+    mock_request.reset()
+
+    test_path = '/'
+    api.get(test_path)
+    assert mock_request.call_args[0][0] == 'GET'
+    assert mock_request.call_args[0][1] == access_url + test_path
+    mock_request.reset()
+
+    test_path = '//'
+    api.get(test_path)
+    assert mock_request.call_args[0][0] == 'GET'
+    assert mock_request.call_args[0][1] == access_url + test_path


### PR DESCRIPTION
For background, see: https://jira.mesosphere.com/browse/DCOS-13496

This PR makes it such that the URL passing is raw -- without hidden logic.

Unit test was added to clearly demonstrate URL handling.

Marathon integration test was added to ensure refactor does not break modules