### PR TITLE
update QUALITY jira project to DCOS

### DIFF
--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -7,14 +7,14 @@ What features does this change enable? What bugs does this change fix?
 
 These JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:
 
-  - [QUALITY-<number>](https://jira.mesosphere.com/browse/QUALITY-<number>) Foo the Bar so it stops Bazzing.
+  - [DCOS-<number>](https://jira.mesosphere.com/browse/DCOS-<number>) Foo the Bar so it stops Bazzing.
 
 
 ## Related tickets (optional)
 
 Other tickets related to this change:
 
-  - [QUALITY-<number>](https://jira.mesosphere.com/browse/QUALITY-<number>) Foo the Bar so it stops Bazzing.
+  - [DCOS-<number>](https://jira.mesosphere.com/browse/DCOS-<number>) Foo the Bar so it stops Bazzing.
 
 
 ## Related `dcos-launch` and `dcos` PRs


### PR DESCRIPTION
## High-level description

JIRA was cleaned up so that the QUALITY project doesn't exist, and tickets that were formerly put there now go into DCOS.

## Corresponding DC/OS tickets (obligatory)

None

## Related tickets (optional)

None

## Related `dcos-launch` and `dcos` PRs

None

## Checklist for all PRs

  - [ ] Included a test which will fail if code is reverted but test is not. If there is no test please explain here: this is a change to the PR template
  - [ ] Include a test in `dcos-integration-tests` in https://github.com/dcos/dcos or explain why this is not applicable: this is the PR template
  - [ ] Include a test in https://github.com/dcos/dcos-launch or explain why this is not applicable: this is the PR template

[Integration tests](https://teamcity.mesosphere.io/project.html?projectId=DcosIo_DcosLaunch_IntegrationTests&tab=projectOverview) were run and

  - [ ] AWS Cloudformation Simple passed (link to job: )
  - [ ] Onprem-AWS passed (link to job: )
  - [ ] Onprem-GCE passed (link to job: )

