### PR TITLE
Display stderr when CLI command fails

### DIFF
--- a/dcos_test_utils/dcos_cli.py
+++ b/dcos_test_utils/dcos_cli.py
@@ -93,13 +93,19 @@ class DcosCli():
 
         log.info('CMD: {!r}'.format(cmd))
 
-        process = subprocess.run(
-            cmd,
-            stdin=stdin,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-            env=self.env,
-            check=True)
+        try:
+            process = subprocess.run(
+                cmd,
+                stdin=stdin,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                env=self.env,
+                check=True)
+        except subprocess.CalledProcessError as e:
+            if e.stderr:
+                stderr = e.stderr.decode('utf-8')
+                log.error('STDERR: {}'.format(stderr))
+            raise
 
         stdout, stderr = process.stdout.decode('utf-8'), process.stderr.decode('utf-8')
 

--- a/tests/test_dcos_cli.py
+++ b/tests/test_dcos_cli.py
@@ -1,0 +1,24 @@
+import pytest
+import subprocess
+
+from dcos_test_utils import dcos_cli
+
+
+def test_exec_command(caplog):
+    cli = dcos_cli.DcosCli('')
+    stdout, stderr = cli.exec_command(
+        ['/bin/sh', '-c', 'echo "hello, world!"']
+    )
+    assert stdout == 'hello, world!\n'
+    assert stderr == ''
+    assert any(rec.message.startswith('CMD:') for rec in caplog.records)
+    assert any(rec.message.startswith('STDOUT:') for rec in caplog.records)
+    assert any(rec.message.startswith('STDERR:') for rec in caplog.records)
+
+
+def test_exec_command_fail(caplog):
+    cli = dcos_cli.DcosCli('')
+    with pytest.raises(subprocess.CalledProcessError):
+        cli.exec_command(['/bin/sh', '-c', 'does-not-exist'])
+    assert any(rec.message.startswith('CMD:') for rec in caplog.records)
+    assert any(rec.message.startswith('STDERR:') for rec in caplog.records)


### PR DESCRIPTION
## High-level description

Add logging of stderr when a command fails in the `dcos_cli` module.


## Corresponding DC/OS tickets (obligatory)

These JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

  - [DCOS_OSS-3620](https://jira.mesosphere.com/browse/DCOS_OSS-3620) Log stderr on failing command execution


## Related tickets (optional)

Other tickets related to this change:



## Related `dcos-launch` and `dcos` PRs

Is this change going to be propagated up into another repo? Test the change by bumping the `dcos-test-utils` SHA to point to these changes to test it. Link the corresponding PRs here:

https://github.com/dcos/dcos/pull/2971

## Checklist for all PRs

  - [x] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [ ] Include a test in `dcos-integration-tests` in https://github.com/dcos/dcos or explain why this is not applicable:
Changes logging only, tested in local repo
  - [ ] Include a test in https://github.com/dcos/dcos-launch or explain why this is not applicable:
Changes logging only, tested in local repo

[Integration tests](https://teamcity.mesosphere.io/project.html?projectId=DcosIo_DcosLaunch_IntegrationTests&tab=projectOverview) were run and

  - [ ] AWS Cloudformation Simple passed (link to job: )
  - [ ] Onprem-AWS passed (link to job: )
  - [ ] Onprem-GCE passed (link to job: )

**PLEASE FILL IN THE TEMPLATE ABOVE** / **DO NOT REMOVE ANY SECTIONS ABOVE THIS LINE**


## Instructions and review process

**What is the review process and when will my changes land?**

All PRs require 2 approvals using GitHub's [pull request reviews](https://help.github.com/articles/about-pull-request-reviews/).

Reviewers should be:
* Developers who understand the code being modified.
* Developers responsible for code that interacts with or depends on the code being modified.

It is best to proactively ask for 2 reviews by @mentioning the candidate reviewers in the PR comments area. The responsibility is on the developer submitting the PR to follow-up with reviewers and make sure a PR is reviewed in a timely manner.