### PR TITLE
pytest_dcos/plugin: dcos_api_session should not wait_for_dcos()

### DIFF
--- a/pytest_dcos/plugin.py
+++ b/pytest_dcos/plugin.py
@@ -20,5 +20,4 @@ def dcos_api_session_factory():
 @pytest.fixture(scope='session')
 def dcos_api_session(dcos_api_session_factory):
     api = dcos_api_session_factory.create()
-    api.wait_for_dcos()
     return api


### PR DESCRIPTION
## High-level description

What features does this change enable? What bugs does this change fix?

This PR modifies the `dcos_api_session` fixture so it does not require DC/OS to be in a healthy state. This step is typically not necessary as the tests are only performed once the cluster is healthy, anyway. Also, having this check prevents us from interacting with the cluster while we inject faults into it.


## Corresponding DC/OS tickets (obligatory)

These JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

  - [DCOS-39296](https://jira.mesosphere.com/browse/DCOS-39296) integration tests: dcos_api_session should not wait_for_dcos


## Related tickets (optional)

Other tickets related to this change:

  - [DCOS-<number>](https://jira.mesosphere.com/browse/DCOS-<number>) Foo the Bar so it stops Bazzing.


## Related `dcos-launch` and `dcos` PRs

Is this change going to be propagated up into another repo? Test the change by bumping the `dcos-test-utils` SHA to point to these changes to test it. Link the corresponding PRs here:


## Checklist for all PRs

  - [ ] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [ ] Include a test in `dcos-integration-tests` in https://github.com/dcos/dcos or explain why this is not applicable:
  - [ ] Include a test in https://github.com/dcos/dcos-launch or explain why this is not applicable:

[Integration tests](https://teamcity.mesosphere.io/project.html?projectId=DcosIo_DcosTestUtils) were run and

  - [ ] Integration Test - Enterprise (link to job: )
  - [ ] Integration Test - Open (link to job: )