### PR TITLE
Fix indefinite blocking of wait_for_ssh_connection

### DIFF
--- a/dcos_test_utils/ssh_client.py
+++ b/dcos_test_utils/ssh_client.py
@@ -169,7 +169,7 @@ class SshClient:
         """
         return self.command(host, ['pwd'], port=port).decode().strip()
 
-    @retrying.retry(wait_fixed=1000)
+    @retrying.retry(wait_fixed=1000, stop_max_attempt_number=1800)
     def wait_for_ssh_connection(self, host: str, port: int=22) -> None:
         """ Blocks until SSH connection can be established
 

--- a/dcos_test_utils/ssh_client.py
+++ b/dcos_test_utils/ssh_client.py
@@ -169,7 +169,7 @@ class SshClient:
         """
         return self.command(host, ['pwd'], port=port).decode().strip()
 
-    @retrying.retry(wait_fixed=1000, stop_max_attempt_number=1800)
+    @retrying.retry(wait_fixed=1000, stop_max_attempt_number=600)
     def wait_for_ssh_connection(self, host: str, port: int=22) -> None:
         """ Blocks until SSH connection can be established
 


### PR DESCRIPTION
## High-level description

This commit solves a bug that `wait_for_ssh_connection` can be blocked indefinitely if it's not possible to establish an SSH connection to the server.

The proposed is a "fallback" solution, meaning that it just enforces a maximum number of retries (30 minutes). Ideally, the `tunnel.command` should check for authentication errors and throw a different type of exception.

## Corresponding DC/OS tickets (obligatory)

  - [DCOS-41428](https://jira.mesosphere.com/browse/DCOS-41428) DC/OS launch waiting indefinitely for SSH to complete

## Checklist for all PRs

  - [ ] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [ ] Include a test in `dcos-integration-tests` in https://github.com/dcos/dcos or explain why this is not applicable:
  - [ ] Include a test in https://github.com/dcos/dcos-launch or explain why this is not applicable:

[Integration tests](https://teamcity.mesosphere.io/project.html?projectId=DcosIo_DcosTestUtils) were run and

  - [ ] Integration Test - Enterprise (link to job: )
  - [ ] Integration Test - Open (link to job: )
