### PR TITLE
Fix endpoint for slaves state

### DIFF
--- a/dcos_test_utils/dcos_api.py
+++ b/dcos_test_utils/dcos_api.py
@@ -372,7 +372,7 @@ class DcosApiSession(helpers.ARNodeApiClientMixin, helpers.RetryCommonHttpErrors
             # slaves can be unknown here. For those, this endpoint
             # returns a 404. Retry in this case, until this endpoint
             # is confirmed to work for all known agents.
-            uri = '/slave/{}/slave%281%29/state.json'.format(slave_id)
+            uri = '/slave/{}/slave%281%29/state'.format(slave_id)
             r = self.get(uri)
             if r.status_code == 404:
                 return False


### PR DESCRIPTION
## High-level description

Fix endpoints for mesos slaves state


Currently _wait_for_srouter_slaves_endpoints function is broken :
Method here: https://github.com/dcos/dcos-test-utils/blob/master/dcos_test_utils/dcos_api.py#L357-L382
Error log here:  https://pastebin.com/EspfqANM

The API call that is executed here: https://github.com/dcos/dcos-test-utils/blob/master/dcos_test_utils/dcos_api.py#L375-L376    is returning 404 errors from the Windows nodes 

According to the documentation : http://mesos.apache.org/documentation/latest/endpoints/slave/state/  :  the endpoint address should not have the .json ending

Removing '.json' from the uri returns 200 from both Linux and Windows nodes and the tests pass.
