### PR TITLE
Fixed CLI usage to resolve DC/OS EE integration test issues.

### DIFF
--- a/dcos_test_utils/dcos_cli.py
+++ b/dcos_test_utils/dcos_cli.py
@@ -158,20 +158,26 @@ class DcosCli():
         self.exec_command(
             ["dcos", "package", "install", "dcos-enterprise-cli", "--cli", "--yes"])
 
-    def login_enterprise(self, username=None, password=None):
+    def login_enterprise(self, username=None, password=None, provider=None):
         """ Authenticates the CLI with the setup Mesosphere Enterprise DC/OS cluster
 
         :param username: username to login with
         :type username: str
         :param password: password to use with username
         :type password: str
+        :param provider: authentication type to use
+        :type password: str
         """
         if not username:
             username = os.environ['DCOS_LOGIN_UNAME']
         if not password:
             password = os.environ['DCOS_LOGIN_PW']
-        stdout, stderr = self.exec_command(
-            ["dcos", "auth", "login", "--username={}".format(username), "--password={}".format(password)])
+
+        command = ["dcos", "auth", "login", "--username={}".format(username), "--password={}".format(password)]
+        if provider:
+            command.append("--provider={}".format(provider))
+
+        stdout, stderr = self.exec_command(command)
         assert stdout == 'Login successful!\n'
         assert stderr == ''
 

--- a/dcos_test_utils/dcos_cli.py
+++ b/dcos_test_utils/dcos_cli.py
@@ -156,7 +156,7 @@ class DcosCli():
         assert stdout == ''
         assert stderr == ''
         self.exec_command(
-            ["dcos", "package", "install", "dcos-enterprise-cli", "--cli", "--global", "--yes"])
+            ["dcos", "package", "install", "dcos-enterprise-cli", "--cli", "--yes"])
 
     def login_enterprise(self, username=None, password=None):
         """ Authenticates the CLI with the setup Mesosphere Enterprise DC/OS cluster


### PR DESCRIPTION
## High-level description

We now use the 1.12 CLI but some tests started to fail in DC/OS EE. These commits are here to fix the situation (it will also require a fix in DC/OS EE).


## Corresponding DC/OS tickets (obligatory)

These JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

  - [DCOS-44391](https://jira.mesosphere.com/browse/DCOS-44391) Change of --global flag behavior in CLI causes the dcos-enterprise tests to fail.


## Related tickets (optional)

Other tickets related to this change:

  - [DCOS-<number>](https://jira.mesosphere.com/browse/DCOS-<number>) Foo the Bar so it stops Bazzing.


## Related `dcos-launch` and `dcos` PRs

Is this change going to be propagated up into another repo? Test the change by bumping the `dcos-test-utils` SHA to point to these changes to test it. Link the corresponding PRs here:


## Checklist for all PRs

  - [ ] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [ ] Include a test in `dcos-integration-tests` in https://github.com/dcos/dcos or explain why this is not applicable:
  - [ ] Include a test in https://github.com/dcos/dcos-launch or explain why this is not applicable:

[Integration tests](https://teamcity.mesosphere.io/project.html?projectId=DcosIo_DcosTestUtils) were run and

  - [ ] Integration Test - Enterprise (link to job: )
  - [ ] Integration Test - Open (link to job: )


**PLEASE FILL IN THE TEMPLATE ABOVE** / **DO NOT REMOVE ANY SECTIONS ABOVE THIS LINE**


## Instructions and review process

**What is the review process and when will my changes land?**

All PRs require 2 approvals using GitHub's [pull request reviews](https://help.github.com/articles/about-pull-request-reviews/).

Reviewers should be:
* Developers who understand the code being modified.
* Developers responsible for code that interacts with or depends on the code being modified.

It is best to proactively ask for 2 reviews by @mentioning the candidate reviewers in the PR comments area. The responsibility is on the developer submitting the PR to follow-up with reviewers and make sure a PR is reviewed in a timely manner.