### PR TITLE
Allow running tests if there are explicitly no agents

### DIFF
--- a/dcos_test_utils/dcos_api.py
+++ b/dcos_test_utils/dcos_api.py
@@ -157,9 +157,9 @@ class DcosApiSession(helpers.ARNodeApiClientMixin, helpers.RetryCommonHttpErrors
         return {
             'auth_user': auth_user,
             'dcos_url': os.getenv('DCOS_DNS_ADDRESS', 'http://leader.mesos'),
-            'masters': masters.split(',') if masters else None,
-            'slaves': slaves.split(',') if slaves else None,
-            'public_slaves': public_slaves.split(',') if public_slaves else None}
+            'masters': masters.split(',') if masters is not None else None,
+            'slaves': slaves.split(',') if slaves is not None else None,
+            'public_slaves': public_slaves.split(',') if public_slaves is not None else None}
 
     @property
     def masters(self) -> List[str]:
@@ -442,7 +442,7 @@ class DcosApiSession(helpers.ARNodeApiClientMixin, helpers.RetryCommonHttpErrors
         if wait_for_hosts and not node_lists_set:
             raise Exception(
                 'This cluster is set to wait for hosts, however, not all host lists '
-                'were suppplied. Please set all three environment variables of MASTER_HOSTS, '
+                'were supplied. Please set all three environment variables of MASTER_HOSTS, '
                 'SLAVE_HOSTS, and PUBLIC_SLAVE_HOSTS to the appropriate cluster IPs (comma separated). '
                 'Alternatively, set WAIT_FOR_HOSTS=false in the environment to use whichever hosts '
                 'are currently registered.')


### PR DESCRIPTION
## High-level description

This allows some integration tests to be run if there are no agents (or public agents) in the cluster.

See https://jira.mesosphere.com/browse/DCOS_OSS-3862.

## Corresponding DC/OS tickets (obligatory)

These JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

  - [DCOS_OSS-3862](https://jira.mesosphere.com/browse/DCOS_OSS-3862) DC/OS Test Utils - DcosApiSession.get_args_from_env assumes agents env var not set if there are no agents

## Checklist for all PRs

  - [ ] Included a test which will fail if code is reverted but test is not. If there is no test please explain here: There just isn't the testing infrastructure here.
  - [ ] Include a test in `dcos-integration-tests` in https://github.com/dcos/dcos or explain why this is not applicable: This is just a developer convenience.
  - [ ] Include a test in https://github.com/dcos/dcos-launch or explain why this is not applicable:  This is just a developer convenience.