### PR TITLE
dcos_test_utils/marathon.py: delete marathon groups on purge

### DIFF
--- a/dcos_test_utils/marathon.py
+++ b/dcos_test_utils/marathon.py
@@ -318,6 +318,8 @@ class Marathon(RetryCommonHttpErrorsMixin, ApiClientSession):
         for pod in pods_response.json():
             log.info('Deleting pod: {}'.format(pod['id']))
             self.delete('/v2/pods' + pod['id'], params=FORCE_PARAMS)
+        log.info('Deleting groups')
+        self.delete('/v2/groups/', params=FORCE_PARAMS)
         self.wait_for_deployments_complete()
 
     @retrying.retry(


### PR DESCRIPTION
## High-level description

https://jira.mesosphere.com/browse/DCOS-34466 describes that some tests leak Marathon groups (and apps, pods) during DC/OS Enterprise PR runs.

This is now interfering with other tests.
We are going to make this helper clean up pods, then we are going to apply it to DC/OS OSS and DC/OS Enterprise.
I think there is no controversy about the former.
See conversation on the JIRA about the latter - we can get to that.

## Corresponding DC/OS tickets (obligatory)

These JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

  - [DCOS-34466](https://jira.mesosphere.com/browse/DCOS-34466) DC/OS Enterprise Integration tests - Make sure that Marathon is cleaned up between tests.

## Related `dcos-launch` and `dcos` PRs

Is this change going to be propagated up into another repo? Test the change by bumping the `dcos-test-utils` SHA to point to these changes to test it. Link the corresponding PRs here:


## Checklist for all PRs

  - [ ] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [ ] Include a test in `dcos-integration-tests` in https://github.com/dcos/dcos or explain why this is not applicable:
  - [ ] Include a test in https://github.com/dcos/dcos-launch or explain why this is not applicable:

[Integration tests](https://teamcity.mesosphere.io/project.html?projectId=DcosIo_DcosTestUtils) were run and

  - [ ] Integration Test - Enterprise (link to job: )
  - [ ] Integration Test - Open (link to job: )


**PLEASE FILL IN THE TEMPLATE ABOVE** / **DO NOT REMOVE ANY SECTIONS ABOVE THIS LINE**


## Instructions and review process

**What is the review process and when will my changes land?**

All PRs require 2 approvals using GitHub's [pull request reviews](https://help.github.com/articles/about-pull-request-reviews/).

Reviewers should be:
* Developers who understand the code being modified.
* Developers responsible for code that interacts with or depends on the code being modified.

It is best to proactively ask for 2 reviews by @mentioning the candidate reviewers in the PR comments area. The responsibility is on the developer submitting the PR to follow-up with reviewers and make sure a PR is reviewed in a timely manner.