### PR TITLE
Makes dcos_cli.exec return the full process object. Marks exec_command as deprecated

### DIFF
--- a/dcos_test_utils/dcos_cli.py
+++ b/dcos_test_utils/dcos_cli.py
@@ -14,8 +14,9 @@ import subprocess
 import tempfile
 from typing import Optional
 
-import deprecation
 import requests
+
+import deprecation
 
 log = logging.getLogger(__name__)
 
@@ -106,8 +107,8 @@ class DcosCli():
         :returns: A tuple with stdout and stderr
         :rtype: subprocess.CompletedProcess
 
-        :raises subprocess.CalledProcessError: When check=True if the returncode of \
-        cmd is not 0
+        :raises subprocess.CalledProcessError: When check=True
+        if the returncode of cmd is not 0
         exception description.
         """
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,5 +3,6 @@ pytest
 requests
 retrying
 tox
+deprecation
 
 sphinx

--- a/tests/test_dcos_cli.py
+++ b/tests/test_dcos_cli.py
@@ -1,9 +1,11 @@
-import pytest
 import subprocess
 
+import deprecation
+import pytest
 from dcos_test_utils import dcos_cli
 
 
+@deprecation.deprecated(details="Deprecated in favor of the `exec` function. DCOS-44823")
 def test_exec_command(caplog):
     cli = dcos_cli.DcosCli('')
     stdout, stderr = cli.exec_command(
@@ -16,9 +18,46 @@ def test_exec_command(caplog):
     assert any(rec.message.startswith('STDERR:') for rec in caplog.records)
 
 
+@deprecation.deprecated(details="Deprecated in favor of the `exec` function. DCOS-44823")
 def test_exec_command_fail(caplog):
     cli = dcos_cli.DcosCli('')
     with pytest.raises(subprocess.CalledProcessError):
         cli.exec_command(['/bin/sh', '-c', 'does-not-exist'])
     assert any(rec.message.startswith('CMD:') for rec in caplog.records)
+    assert any(rec.message.startswith('STDERR:') for rec in caplog.records)
+
+
+def test_exec(caplog):
+    cli = dcos_cli.DcosCli('')
+    process = cli.exec(
+        ['/bin/sh', '-c', 'echo "hello, world!"']
+    )
+    assert process.stdout == b'hello, world!\n'
+    assert process.stderr == b''
+    assert process.returncode == 0
+    assert any(rec.message.startswith('CMD:') for rec in caplog.records)
+    assert any(rec.message.startswith('STDOUT:') for rec in caplog.records)
+    assert any(rec.message.startswith('STDERR:') for rec in caplog.records)
+
+
+def test_exec_fail(caplog):
+    cli = dcos_cli.DcosCli('')
+    with pytest.raises(subprocess.CalledProcessError):
+        cli.exec(['/bin/sh', '-c', 'does-not-exist'])
+    assert any(rec.message.startswith('CMD:') for rec in caplog.records)
+    assert any(rec.message.startswith('STDERR:') for rec in caplog.records)
+    assert any(rec.message.startswith('STDOUT:') for rec in caplog.records)
+
+
+def test_exec_fail_without_check(caplog):
+    cli = dcos_cli.DcosCli('')
+    process = cli.exec(
+        ['/bin/sh', '-c', 'does-not-exist'],
+        check=False
+    )
+    assert process.stdout == b''
+    assert b'does-not-exist' in process.stderr
+    assert process.returncode == 127
+    assert any(rec.message.startswith('CMD:') for rec in caplog.records)
+    assert any(rec.message.startswith('STDOUT:') for rec in caplog.records)
     assert any(rec.message.startswith('STDERR:') for rec in caplog.records)


### PR DESCRIPTION
## High-level description

This feature enables Edge-LB tests to look at the returncode of the command. It also enriches the API of cli test with the full content of the process object.

Please see https://github.com/dcos/dcos-test-utils/pull/61 for context

## Corresponding DC/OS tickets (obligatory)

These JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

  - [DCOS-43648](https://jira.mesosphere.com/browse/DCOS-43648) Add support for returncode on dcos-test-utils cli


## Related tickets (optional)

Other tickets related to this change:

There is a follow up epic with the rest of the work.
  - [DCOS-44823](https://jira.mesosphere.com/browse/DCOS-44823) dcos-test-utils - exec cmd contributions to other projects

## Checklist for all PRs

  - [x] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [ ] Include a test in `dcos-integration-tests` in https://github.com/dcos/dcos or explain why this is not applicable:
  - [ ] Include a test in https://github.com/dcos/dcos-launch or explain why this is not applicable:

[Integration tests](https://teamcity.mesosphere.io/project.html?projectId=DcosIo_DcosTestUtils) were run and

  - [ ] Integration Test - Enterprise (link to job: )
  - [ ] Integration Test - Open (link to job: )


**PLEASE FILL IN THE TEMPLATE ABOVE** / **DO NOT REMOVE ANY SECTIONS ABOVE THIS LINE**


## Instructions and review process

**What is the review process and when will my changes land?**

All PRs require 2 approvals using GitHub's [pull request reviews](https://help.github.com/articles/about-pull-request-reviews/).

Reviewers should be:
* Developers who understand the code being modified.
* Developers responsible for code that interacts with or depends on the code being modified.

It is best to proactively ask for 2 reviews by @mentioning the candidate reviewers in the PR comments area. The responsibility is on the developer submitting the PR to follow-up with reviewers and make sure a PR is reviewed in a timely manner.