### PR TITLE
Use the correct CLI for the given DC/OS version

### DIFF
--- a/dcos_test_utils/dcos_cli.py
+++ b/dcos_test_utils/dcos_cli.py
@@ -18,7 +18,7 @@ import requests
 
 log = logging.getLogger(__name__)
 
-DCOS_CLI_URL = os.getenv('DCOS_CLI_URL', 'https://downloads.dcos.io/binaries/cli/linux/x86-64/dcos-1.12/dcos')
+DCOS_CLI_URL = os.getenv('DCOS_CLI_URL', 'https://downloads.dcos.io/cli/releases/binaries/dcos/linux/x86-64/latest/dcos')  # noqa: E501
 
 
 class DcosCli():


### PR DESCRIPTION
This makes sure the correct DC/OS CLI URL version is used during integration

The DC/OS version is read from gen/calc.py. For DC/OS < 1.14, it will return
https://downloads.dcos.io/binaries/cli/linux/x86-64/dcos-1.XX/dcos with the
appropriate version. Starting from DC/OS 1.14 it will return the DC/OS version
agnostic CLI URL.

The URL can be overwritten through the `DCOS_CLI_URL` env var.

https://jira.mesosphere.com/browse/DCOS-45807
https://github.com/dcos/dcos/pull/4142

DC/OS versions:
- [1.10] There I think we should update the teamcity parameter as it uses an old version of dcos-test-utils in a different way.
- [1.11] https://github.com/mesosphere/dcos-enterprise/pull/4586
- [1.12] https://github.com/mesosphere/dcos-enterprise/pull/4585
- [1.13] https://github.com/dcos/dcos/pull/4211