### PR TITLE
Add plugin for collecting xfailflakes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -86,3 +86,4 @@ ENV/
 
 # Rope project settings
 .ropeproject
+xfailflake.json

--- a/pytest_dcos/plugin.py
+++ b/pytest_dcos/plugin.py
@@ -57,7 +57,15 @@ def _write_xfailflake_report(tests):
     json.dump(report, open('xfailflake.json', 'w'))
 
 
+def pytest_addoption(parser):
+    parser.addoption("--xfailflake-report", action="store_true",
+                     help="Write a report of all tests marked flakey using the xfailflake marker to xfailflake.json.")
+
+
 def pytest_collection_modifyitems(session, config, items):
+    if not config.getoption("--xfailflake-report"):
+        return
+
     _write_xfailflake_report(items)
 
 

--- a/pytest_dcos/plugin.py
+++ b/pytest_dcos/plugin.py
@@ -1,7 +1,10 @@
+import datetime
+import json
 import os
-
 import pytest
 
+from typing import Any
+from _pytest.python import Function
 from dcos_test_utils import dcos_api, enterprise, logger
 
 logger.setup(os.getenv('LOG_LEVEL', 'DEBUG'))
@@ -22,3 +25,79 @@ def dcos_api_session(dcos_api_session_factory):
     api = dcos_api_session_factory.create()
     api.wait_for_dcos()
     return api
+
+
+def _iter_xfail_markers(item):
+    xfailflake_markers = [
+        marker for marker in item.iter_markers() if marker.name == 'xfailflake'
+    ]
+    for xfailflake_marker in xfailflake_markers:
+        assert 'reason' in xfailflake_marker.kwargs
+        assert 'jira' in xfailflake_marker.kwargs
+        assert xfailflake_marker.kwargs['jira'].startswith('DCOS')
+
+        yield xfailflake_marker
+
+
+def _write_xfailflake_report(tests):
+    """
+    Writes a report of all xfailflake tagged tests to the current directory.
+    """
+    report = []
+
+    for test in tests:
+        for xfailflake_marker in _iter_xfail_markers(test):
+            report.append({
+                "name": test.name,
+                "module": test.module.__name__,
+                "path": test.module.__file__,
+                "xfailflake": xfailflake_marker.kwargs
+            })
+
+    json.dump(report, open('xfailflake.json', 'w'))
+
+
+def pytest_collection_modifyitems(session, config, items):
+    _write_xfailflake_report(items)
+
+
+def _add_xfail_markers(item: Function) -> None:
+    """
+    Mute flaky Integration Tests with custom pytest marker.
+    Rationale for doing this is mentioned at DCOS-45308.
+    """
+    xfailflake_markers = [
+        marker for marker in item.iter_markers() if marker.name == 'xfailflake'
+    ]
+    for xfailflake_marker in xfailflake_markers:
+        assert 'reason' in xfailflake_marker.kwargs
+        assert 'jira' in xfailflake_marker.kwargs
+        assert xfailflake_marker.kwargs['jira'].startswith('DCOS')
+        # Show the JIRA in the printed reason.
+        xfailflake_marker.kwargs['reason'] = '{jira} - {reason}'.format(
+            jira=xfailflake_marker.kwargs['jira'],
+            reason=xfailflake_marker.kwargs['reason'],
+        )
+        date_text = xfailflake_marker.kwargs['since']
+        try:
+            datetime.datetime.strptime(date_text, '%Y-%m-%d')
+        except ValueError:
+            message = (
+                'Incorrect date format for "since", should be YYYY-MM-DD'
+            )
+            raise ValueError(message)
+
+        # The marker is not "strict" unless that is explicitly stated.
+        # That means that by default, no error is raised if the test passes or
+        # fails.
+        strict = xfailflake_marker.kwargs.get('strict', False)
+        xfailflake_marker.kwargs['strict'] = strict
+        xfail_marker = pytest.mark.xfail(
+            *xfailflake_marker.args,
+            **xfailflake_marker.kwargs,
+        )
+        item.add_marker(xfail_marker)
+
+
+def pytest_runtest_setup(item: Any) -> None:
+    _add_xfail_markers(item)

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -1,2 +1,33 @@
+import json
+import pytest
+
+
 def test_dcos_api_session_factory_fixture_imported(dcos_api_session_factory):
     pass
+
+
+@pytest.mark.xfailflake(
+    jira='DCOS-1337',
+    reason='A reason',
+    since='2019-01-25'
+)
+def test_xfailflake():
+    # Test always fails, but the test suite should still pass.
+    assert False
+
+
+def test_xfailflake_report():
+    # This should be written out by the collect process.
+    report = json.load(open('xfailflake.json'))
+    assert report == [
+        {
+            'module': 'test_plugin',
+            'name': 'test_xfailflake',
+            'path': __file__,
+            'xfailflake': {
+                'jira': 'DCOS-1337',
+                'reason': 'A reason',
+                'since': '2019-01-25'
+            }
+        }
+    ]

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -1,29 +1,48 @@
 import json
-import pytest
+import os
+
+
+xfailflake_test = """
+    import pytest
+
+    @pytest.mark.xfailflake(
+        jira='DCOS-1337',
+        reason='A reason',
+        since='2019-01-25'
+    )
+    def test_xfailflake():
+        # Test always fails, but the test suite should still pass.
+        assert False
+"""
 
 
 def test_dcos_api_session_factory_fixture_imported(dcos_api_session_factory):
     pass
 
 
-@pytest.mark.xfailflake(
-    jira='DCOS-1337',
-    reason='A reason',
-    since='2019-01-25'
-)
-def test_xfailflake():
-    # Test always fails, but the test suite should still pass.
-    assert False
+def test_xfailflake_no_report(testdir):
+    testdir.makepyfile(xfailflake_test)
+
+    result = testdir.runpytest()
+    result.assert_outcomes(xfailed=1)
+
+    assert not os.path.exists('xfailflake.json')
 
 
-def test_xfailflake_report():
-    # This should be written out by the collect process.
+def test_xfailflake_write_report(testdir):
+    testdir.makepyfile(xfailflake_test)
+
+    result = testdir.runpytest("--xfailflake-report")
+    result.assert_outcomes(xfailed=1)
+
+    assert os.path.exists('xfailflake.json')
+
     report = json.load(open('xfailflake.json'))
     assert report == [
         {
-            'module': 'test_plugin',
+            'module': 'test_xfailflake_write_report',
             'name': 'test_xfailflake',
-            'path': __file__,
+            'path': os.path.join(os.getcwd(), 'test_xfailflake_write_report.py'),
             'xfailflake': {
                 'jira': 'DCOS-1337',
                 'reason': 'A reason',

--- a/tox.ini
+++ b/tox.ini
@@ -9,7 +9,7 @@ application-import-names = dcos_test_utils
 import-order-style = smarkets
 
 [pytest]
-addopts = -rs -vv
+addopts = -rs -vv -p pytester
 testpaths = tests
 
 [testenv]


### PR DESCRIPTION
## High-level description

This moves the xfailflake plugin code into dcos-test-utils so that it does not need to be duplicated for every branch and repository. It also adds a pytest hook to write out a report of all tests that are marked flakey.

## Corresponding DC/OS tickets (obligatory)

These JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

  - [DCOS-46439](https://jira.mesosphere.com/browse/DCOS-46439) xfailflake dashboard - collect marked issues without a cluster and without regex

## Related `dcos-launch` and `dcos` PRs

Is this change going to be propagated up into another repo? Test the change by bumping the `dcos-test-utils` SHA to point to these changes to test it. Link the corresponding PRs here:


## Checklist for all PRs

  - [x] Included a test which will fail if code is reverted but test is not.
  - [x] Include a test in `dcos-integration-tests` in https://github.com/dcos/dcos or explain why this is not applicable: code will run on all dcos-integration-test runs, so the unit test is sufficient as it will always be exercised.
  - [x] Include a test in https://github.com/dcos/dcos-launch or explain why this is not applicable: I don't think dcos-launch is affected.

[Integration tests](https://teamcity.mesosphere.io/project.html?projectId=DcosIo_DcosTestUtils) were run and

  - [x] Integration Test - Enterprise (link to job: https://teamcity.mesosphere.io/viewLog.html?buildId=1527495&buildTypeId=DcOs_Enterprise_Test_DockerBased_E2eGroup1)
  - [x] Integration Test - Open (link to job: https://teamcity.mesosphere.io/viewLog.html?buildId=1527467&buildTypeId=DcOs_Open_Test_IntegrationTest_AwsOnpremWStaticBackendGroup1)