### PR TITLE
DCOS-46439 - Replace -vv with --debug in dcos-cli command line to support older versions of DC/OS CLI.

### DIFF
--- a/dcos_test_utils/dcos_cli.py
+++ b/dcos_test_utils/dcos_cli.py
@@ -156,7 +156,7 @@ class DcosCli():
         assert stdout == ''
         assert stderr == ''
         self.exec_command(
-            ["dcos", "-vv", "package", "install", "dcos-enterprise-cli", "--cli", "--yes"])
+            ["dcos", "--debug", "package", "install", "dcos-enterprise-cli", "--cli", "--yes"])
 
     def login_enterprise(self, username=None, password=None, provider=None):
         """ Authenticates the CLI with the setup Mesosphere Enterprise DC/OS cluster


### PR DESCRIPTION
## High-level description

Older versions of dcos-cli (e.g., `0.6.5` the default for DC/OS 1.11) do not support the `-vv` flag, only `--debug`. This PR switches dcos-test-utils to use the older flag to ensure compatibility.


## Corresponding DC/OS tickets (obligatory)

These JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

  - [/DCOS-46439](https://jira.mesosphere.com/browse//DCOS-46439) xfailflake dashboard - collect marked issues without a cluster and without regex

## Related `dcos-launch` and `dcos` PRs

* [BACKPORT] [1.11] DCOS-46439 - Move xfailflake collection to dcos-test-utils:  https://github.com/dcos/dcos/pull/4425 / https://github.com/mesosphere/dcos-enterprise/pull/4556

## Checklist for all PRs

  - [x] Included a test which will fail if code is reverted but test is not. If there is no test please explain here: N/A
  - [x] Include a test in `dcos-integration-tests` in https://github.com/dcos/dcos or explain why this is not applicable: resolves issue with integration test build for 1.11.
  - [x] Include a test in https://github.com/dcos/dcos-launch or explain why this is not applicable: N/A

[Integration tests](https://teamcity.mesosphere.io/project.html?projectId=DcosIo_DcosTestUtils) were run and

  - [x] Integration Test - Enterprise (link to job: https://teamcity.mesosphere.io/viewLog.html?buildId=1559764&buildTypeId=DcOs_Enterprise_Test_DockerBased_E2eGroup1)
  - [x] Integration Test - Open (link to job: https://teamcity.mesosphere.io/viewLog.html?buildId=1559782&buildTypeId=DcOs_Open_Test_IntegrationTest_AwsOnpremWStaticBackendGroup1)