### PR TITLE
DCOS_OSS-4877 - Instead of raising an exception when job results are not ready, return false so that it retries.

### DIFF
--- a/dcos_test_utils/jobs.py
+++ b/dcos_test_utils/jobs.py
@@ -97,9 +97,10 @@ class Jobs(helpers.RetryCommonHttpErrorsMixin, helpers.ApiClientSession):
                     log.info('Job run {} finished.'.format(r_id))
                     return True
                 else:
-                    raise requests.HTTPError(
+                    log.warning(
                         'Waiting for job run {} to be finished, but history for that job run is not available'
-                        .format(r_id), response=rc)
+                        .format(r_id))
+                    return False
             else:
                 raise requests.HTTPError(
                     'Waiting for job run {} to be finished, but getting HTTP status code {}'

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -250,7 +250,7 @@ def test_jobs_run_history_not_available(mock_url, replay_session):
     job_payload = {'id':      'myjob',
                    'history': {'successfulFinishedRuns': [],
                                'failedFinishedRuns':     []}}
-    exp_err_msg = 'Waiting for job run myrun1 to be finished, but history for that job run is not available'
+    exp_err_msg = 'Job run failed - operation was not completed in 2 seconds.'
 
     # lots of responses, but only a few will trigger before timeout
     mock_replay = list((


### PR DESCRIPTION
## High-level description

Previously, dcos-test-utils would raise an exception if jobs results were not yet ready, but exceptions are not retried, so we instead log and return False.

## Corresponding DC/OS tickets (obligatory)

These JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

  - [DCOS_OSS-4877](https://jira.mesosphere.com/browse/DCOS_OSS-4877) Waiting for job run to be finished, but history for that job run is not available


## Related `dcos-launch` and `dcos` PRs

Is this change going to be propagated up into another repo? Test the change by bumping the `dcos-test-utils` SHA to point to these changes to test it. Link the corresponding PRs here:


## Checklist for all PRs

  - [x] Included a test which will fail if code is reverted but test is not.
  - [ ] Include a test in `dcos-integration-tests` in https://github.com/dcos/dcos or explain why this is not applicable:
  - [ ] Include a test in https://github.com/dcos/dcos-launch or explain why this is not applicable:

[Integration tests](https://teamcity.mesosphere.io/project.html?projectId=DcosIo_DcosTestUtils) were run and

  - [x] Integration Test - Enterprise (link to job: )
  - [x] Integration Test - Open (link to job: )