### PR TITLE
Show status code when expected status code is not found

### DIFF
--- a/dcos_test_utils/dcos_api.py
+++ b/dcos_test_utils/dcos_api.py
@@ -386,7 +386,10 @@ class DcosApiSession(helpers.ARNodeApiClientMixin, helpers.RetryCommonHttpErrors
             r = self.get(uri)
             if r.status_code == 404:
                 return False
-            assert r.status_code == 200
+            assert r.status_code == 200, (
+                'Expecting status code 200 for Mesos slave state but got '
+                '{status_code} with body {content}'
+            ).format(status_code=r.status_code, content=r.content)
             data = r.json()
             assert "id" in data
             assert data["id"] == slave_id


### PR DESCRIPTION
## High-level description

This makes one particular error slightly easier to debug.

## Corresponding DC/OS tickets (obligatory)

These JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

  - [DCOS_OSS-5245](DCOS_OSS-5245) Test Utils - _wait_for_srouter_slaves_endpoints - unclear failure.


## Related `dcos-launch` and `dcos` PRs

I will not be urgently bumping this in DC/OS and I prefer to not do this unless a reviewer requests it.

## Checklist for all PRs

  - [ ] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [ ] Include a test in `dcos-integration-tests` in https://github.com/dcos/dcos or explain why this is not applicable:
  - [ ] Include a test in https://github.com/dcos/dcos-launch or explain why this is not applicable:

I cannot think of a viable test for this unless we had a mock Mesos...