### PR TITLE
 Continue checking Mesos slave state even after a 502

### DIFF
--- a/dcos_test_utils/dcos_api.py
+++ b/dcos_test_utils/dcos_api.py
@@ -384,10 +384,9 @@ class DcosApiSession(helpers.ARNodeApiClientMixin, helpers.RetryCommonHttpErrors
                 # returns a 404. Retry in this case, until this endpoint
                 # is confirmed to work for all known agents.
                 404,
-                # We have seen 502 responses that have been followed by 200
-                # responses during an upgrade.
-                # This is likely for the same reason as the 404 responses
-                # described above.
+                # During a node restart or a DC/OS upgrade, this
+                # endpoint returns a 502 temporarily, until the agent has
+                # started up and the Mesos agent HTTP server can be reached.
                 502,
             )
             uri = '/slave/{}/slave%281%29/state'.format(slave_id)

--- a/dcos_test_utils/dcos_api.py
+++ b/dcos_test_utils/dcos_api.py
@@ -385,7 +385,9 @@ class DcosApiSession(helpers.ARNodeApiClientMixin, helpers.RetryCommonHttpErrors
                 # is confirmed to work for all known agents.
                 404,
                 # We have seen 502 responses that have been followed by 200
-                # responses.
+                # responses during an upgrade.
+                # This is likely for the same reason as the 404 responses
+                # described above.
                 502,
             )
             uri = '/slave/{}/slave%281%29/state'.format(slave_id)

--- a/dcos_test_utils/dcos_api.py
+++ b/dcos_test_utils/dcos_api.py
@@ -393,9 +393,9 @@ class DcosApiSession(helpers.ARNodeApiClientMixin, helpers.RetryCommonHttpErrors
             if r.status_code in in_progress_status_codes:
                 return False
             assert r.status_code == 200, (
-                'Expecting status code 200 for Mesos slave state but got '
+                'Expecting status code 200 for GET request to {uri} but got '
                 '{status_code} with body {content}'
-            ).format(status_code=r.status_code, content=r.content)
+            ).format(uri=uri, status_code=r.status_code, content=r.content)
             data = r.json()
             assert "id" in data
             assert data["id"] == slave_id


### PR DESCRIPTION
## High-level description

This continues `wait_for_dcos` in one scenario where it erroneously stopped before.

## Corresponding DC/OS tickets (obligatory)

These JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

  - [DCOS_OSS-5246](https://jira.mesosphere.com/browse/DCOS_OSS-5246) Test Utils - _wait_for_srouter_slaves_endpoints - 502 can be seen before 200

## Related `dcos-launch` and `dcos` PRs

I have no intention of immediately bumping DC/OS. Therefore I will not do this unless a reviewer requests it.

## Checklist for all PRs

  - [ ] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [ ] Include a test in `dcos-integration-tests` in https://github.com/dcos/dcos or explain why this is not applicable:
  - [ ] Include a test in https://github.com/dcos/dcos-launch or explain why this is not applicable:

I cannot think how to test this without a Mesos mock.