### PR TITLE
Continue waiting when Mesos slave endpoint gives 503

### DIFF
--- a/dcos_test_utils/dcos_api.py
+++ b/dcos_test_utils/dcos_api.py
@@ -388,6 +388,10 @@ class DcosApiSession(helpers.ARNodeApiClientMixin, helpers.RetryCommonHttpErrors
                 # endpoint returns a 502 temporarily, until the agent has
                 # started up and the Mesos agent HTTP server can be reached.
                 502,
+                # We have seen this endpoint return 503 with body
+                # b'Agent has not finished recovery' on a cluster which
+                # later became healthy.
+                503,
             )
             uri = '/slave/{}/slave%281%29/state'.format(slave_id)
             r = self.get(uri)


### PR DESCRIPTION
## High-level description

This enables waiting for DC/OS in more cases.

## Related `dcos-launch` and `dcos` PRs

I'd really rather not do this - hopefully a reviewer can tell that this is fine. I'll do this if requested.

## Checklist for all PRs

No tests for the same reason as above.