### PR TITLE
Install dcos-enterprise CLI if not ee plugin is specified

### DIFF
--- a/dcos_test_utils/dcos_cli.py
+++ b/dcos_test_utils/dcos_cli.py
@@ -161,6 +161,8 @@ class DcosCli:
             self.exec_command(['dcos', 'plugin', 'add', '-u', self.core_plugin_url])
         if self.ee_plugin_url:
             self.exec_command(['dcos', 'plugin', 'add', '-u', self.ee_plugin_url])
+        else:
+            self.exec_command(["dcos", "--debug", "package", "install", "dcos-enterprise-cli", "--cli", "--yes"])
 
     def login_enterprise(self, username=None, password=None, provider=None):
         """ Authenticates the CLI with the setup Mesosphere Enterprise DC/OS cluster


### PR DESCRIPTION
1.11 fails with dcos-test-utils master branch. Adding this small line back to fix the problem. DC/OS 1.11 CLI  cannot call "dcos plugin add", so the dcos-enterprise package must be installed.

we can see here: https://github.com/mesosphere/dcos-enterprise/blob/1.11/packages/dcos-integration-test/extra/conftest.py#L265 will call new_cli with no plugin specified
