### PR TITLE
Add helpers to get a pod task's sandbox and pull files from it.

### DIFF
--- a/dcos_test_utils/dcos_api.py
+++ b/dcos_test_utils/dcos_api.py
@@ -664,6 +664,53 @@ class DcosApiSession(helpers.ARNodeApiClientMixin, helpers.RetryCommonHttpErrors
         r.raise_for_status()
         return r.text
 
+    def mesos_pod_sandbox_directory(self, slave_id: str, framework_id: str, executor_id: str, task_id: str) -> str:
+        """ Gets the mesos sandbox directory for a specific task in a pod which is currently running
+
+        :param slave_id: slave ID to pull sandbox from
+        :type slave_id: str
+        :param framework_id: framework_id to pull sandbox from
+        :type frameowork_id: str
+        :param executor_id: executor ID to pull directory sandbox from
+        :type executor_id: str
+        :param task_id: task ID to pull directory sandbox from
+        :type task_id: str
+
+        :returns: the directory of the sandbox
+        :rtype: str
+        """
+        return '{}/tasks/{}'.format(self.mesos_sandbox_directory(slave_id, framework_id, executor_id), task_id)
+
+    def mesos_pod_sandbox_file(
+            self,
+            slave_id: str,
+            framework_id: str,
+            executor_id: str,
+            task_id: str,
+            filename: str) -> str:
+        """ Gets a specific file from a currently-running pod's task sandbox and returns the text content
+
+        :param slave_id: ID of the slave running the task
+        :type slave_id: str
+        :param framework_id: ID of the framework of the task
+        :type framework_id: str
+        :param executor_id: ID of the executor
+        :type executor_id: str
+        :param task_id: ID of the task
+        :type task_id: str
+        :param filename: filename in the sandbox
+        :type filename: str
+
+        :returns: sandbox text contents
+        """
+        r = self.get(
+            '/agent/{}/files/download'.format(slave_id),
+            params={'path': self.mesos_pod_sandbox_directory(
+                slave_id, framework_id, executor_id, task_id) + '/' + filename}
+        )
+        r.raise_for_status()
+        return r.text
+
     def get_version(self) -> str:
         """ Queries the DC/OS version endpoint to get DC/OS version
 


### PR DESCRIPTION
## High-level description

This PR adds new helpers to allow tests to find the sandbox directory associated with a pod task container, and to pull the text content of files contained therein. Such helpers existed already for command (non-pod) tasks.


## Corresponding DC/OS tickets (obligatory)

These JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

  - [DCOS-57093](https://jira.mesosphere.com/browse/DCOS-57093) test_secret_leakage.test_pod_secret_leakage looks flaky


## Related `dcos-launch` and `dcos` PRs

Is this change going to be propagated up into another repo? Test the change by bumping the `dcos-test-utils` SHA to point to these changes to test it. Link the corresponding PRs here:

https://github.com/dcos/dcos/pull/6187


## Checklist for all PRs

  - [x] Included a test which will fail if code is reverted but test is not. If there is no test please explain here: these helpers require a live Mesos agent with pods running
  - [x] Include a test in `dcos-integration-tests` in https://github.com/dcos/dcos or explain why this is not applicable: see https://github.com/mesosphere/dcos-enterprise/pull/6521
  - [x] Include a test in https://github.com/dcos/dcos-launch or explain why this is not applicable: the above EE integration test is sufficient to verify the helper functions added in this PR

[Integration tests](https://teamcity.mesosphere.io/project.html?projectId=DcosIo_DcosTestUtils) were run and

  - [x] Integration Test - Enterprise (link to job: https://teamcity.mesosphere.io/viewLog.html?buildId=2230466&buildTypeId=DcosIo_DcosTestUtils_ToxIntegrationTestEnterprise)
  - [x] Integration Test - Open (link to job: https://teamcity.mesosphere.io/viewLog.html?buildId=2230467&buildTypeId=DcosIo_DcosTestUtils_ToxIntegrationTest)