### PR TITLE
Do not wait for dcos-histroy

### DIFF
--- a/dcos_test_utils/dcos_api.py
+++ b/dcos_test_utils/dcos_api.py
@@ -291,52 +291,6 @@ class DcosApiSession(helpers.ARNodeApiClientMixin, helpers.RetryCommonHttpErrors
     @retrying.retry(wait_fixed=1000,
                     retry_on_result=lambda ret: ret is False,
                     retry_on_exception=lambda x: False)
-    def _wait_for_dcos_history_up(self):
-        r = self.get('/dcos-history-service/ping')
-        # resp_code >= 500 -> backend is still down probably
-        if r.status_code <= 500:
-            log.info("DC/OS History is probably up")
-            return True
-        else:
-            msg = "Waiting for DC/OS History, resp code is: {}"
-            log.info(msg.format(r.status_code))
-            return False
-
-    @retrying.retry(wait_fixed=1000,
-                    retry_on_result=lambda ret: ret is False,
-                    retry_on_exception=lambda x: False)
-    def _wait_for_dcos_history_data(self):
-        ro = self.get('/dcos-history-service/history/last')
-        # resp_code >= 500 -> backend is still down probably
-        if ro.status_code <= 500:
-            json = ro.json()
-            # We have observed cases of the returned JSON being '{}'.
-            if 'slaves' in json:
-                # The json['slaves'] is an array of dicts that must be
-                # mapped to set of hostnames so it can be compared with
-                # all_slaves.
-                # if an agent was removed, it may linger in the history data
-                # so simply check that at least the number agents we expect are present
-                if len(json['slaves']) >= len(self.all_slaves):
-                    return True
-                slaves_from_history_service = set(
-                    map(lambda x: x['hostname'], json['slaves']))
-                log.info('Still waiting for agents to join. Expected: {}, present: {}'.format(
-                    self.all_slaves, slaves_from_history_service))
-                return False
-
-            log.info(
-                'Data on the number of slaves from DC/OS History is not yet '
-                'available'
-            )
-
-        msg = "Waiting for DC/OS History, resp code is: {}"
-        log.info(msg.format(ro.status_code))
-        return False
-
-    @retrying.retry(wait_fixed=1000,
-                    retry_on_result=lambda ret: ret is False,
-                    retry_on_exception=lambda x: False)
     def _wait_for_adminrouter_up(self):
         try:
             # Yeah, we can also put it in retry_on_exception, but
@@ -474,9 +428,7 @@ class DcosApiSession(helpers.ARNodeApiClientMixin, helpers.RetryCommonHttpErrors
         self._wait_for_marathon_up()
         self._wait_for_zk_quorum()
         self._wait_for_slaves_to_join()
-        self._wait_for_dcos_history_up()
         self._wait_for_srouter_slaves_endpoints()
-        self._wait_for_dcos_history_data()
         self._wait_for_metronome()
         self._wait_for_all_healthy_services()
 


### PR DESCRIPTION
## High-level description

Remove dcos-history


## Corresponding DC/OS tickets (obligatory)

These JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

  - [DCOS-58529](https://jira.mesosphere.com/browse/DCOS-58529) Remove dcos-history


## Related tickets (optional)

Other tickets related to this change:

  - [DCOS-<number>](https://jira.mesosphere.com/browse/DCOS-<number>) Foo the Bar so it stops Bazzing.


## Related `dcos-launch` and `dcos` PRs

Is this change going to be propagated up into another repo? Test the change by bumping the `dcos-test-utils` SHA to point to these changes to test it. Link the corresponding PRs here:


## Checklist for all PRs

  - [ ] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [ ] Include a test in `dcos-integration-tests` in https://github.com/dcos/dcos or explain why this is not applicable:
  - [ ] Include a test in https://github.com/dcos/dcos-launch or explain why this is not applicable:

[Integration tests](https://teamcity.mesosphere.io/project.html?projectId=DcosIo_DcosTestUtils) were run and

  - [ ] Integration Test - Enterprise (link to job: )
  - [ ] Integration Test - Open (link to job: )


**PLEASE FILL IN THE TEMPLATE ABOVE** / **DO NOT REMOVE ANY SECTIONS ABOVE THIS LINE**


## Instructions and review process

**What is the review process and when will my changes land?**

All PRs require 2 approvals using GitHub's [pull request reviews](https://help.github.com/articles/about-pull-request-reviews/).

Reviewers should be:
* Developers who understand the code being modified.
* Developers responsible for code that interacts with or depends on the code being modified.

It is best to proactively ask for 2 reviews by @mentioning the candidate reviewers in the PR comments area. The responsibility is on the developer submitting the PR to follow-up with reviewers and make sure a PR is reviewed in a timely manner.