### PR TITLE
Use DCOS_ACS_TOKEN as authentication token.

### DIFF
--- a/dcos_test_utils/dcos_api.py
+++ b/dcos_test_utils/dcos_api.py
@@ -34,6 +34,7 @@ class DcosUser:
     def __init__(self, credentials: dict):
         self.credentials = credentials
         self.auth_token = None
+        self.auth_cookie = None
 
     @property
     def auth_header(self) -> dict:
@@ -143,7 +144,7 @@ class DcosApiSession(helpers.ARNodeApiClientMixin, helpers.RetryCommonHttpErrors
         if dcos_acs_token is None:
             auth_user = DcosUser(helpers.CI_CREDENTIALS)
         else:
-            auth_user = DcosUser({'token': ''})
+            auth_user = DcosUser(None)
             auth_user.auth_token = dcos_acs_token
 
         masters = os.getenv('MASTER_HOSTS')
@@ -239,6 +240,7 @@ class DcosApiSession(helpers.ARNodeApiClientMixin, helpers.RetryCommonHttpErrors
         r.raise_for_status()
         log.info('Received authentication token: {}'.format(r.json()))
         self.auth_user.auth_token = r.json()['token']
+        self.auth_user.auth_cookie = r.cookies['dcos-acs-auth-cookie']
         log.info('Login successful')
         # Set requests auth
         self.session.auth = DcosAuth(self.auth_user.auth_token)

--- a/dcos_test_utils/dcos_api.py
+++ b/dcos_test_utils/dcos_api.py
@@ -225,10 +225,13 @@ class DcosApiSession(helpers.ARNodeApiClientMixin, helpers.RetryCommonHttpErrors
                 username or password of the default user.
         """
         if self.auth_user is None:
+            log.info('No credentials are defined')
             return
 
         if self.auth_user.auth_token is not None:
             log.info('Already logged in as default user')
+            self.session.auth = DcosAuth(self.auth_user.auth_token)
+            return
 
         log.info('Attempting default user login')
         # Explicitly request the default user authentication token by logging in.


### PR DESCRIPTION
## High-level description

The `DCOS_ACS_TOKEN` from `dcos config show core.dcos_acs_token` is an
*authentication* token and not a *login* token such as the CI token used
as the default.
