### PR TITLE
make subprocess.run() call args compatible with Python3.6 used in dc/os

### DIFF
--- a/dcos_test_utils/etcd.py
+++ b/dcos_test_utils/etcd.py
@@ -38,7 +38,8 @@ class EtcdCtl():
             env: dict = {}) -> subprocess.CompletedProcess:
         process = subprocess.run(
             self._base_args.copy() + cmd,
-            capture_output=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
             env=env,
             check=check)
 


### PR DESCRIPTION
## High-level description

Make `subprocess.run()` call compatible with python3.6 used in dc/os.


## Corresponding DC/OS tickets (obligatory)

These JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

  - https://jira.d2iq.com/browse/D2IQ-59030 `introduce RBAC authn&authz`
  - https://jira.d2iq.com/browse/D2IQ-64356 `E2E test for custom external certificate feature`

