### PR TITLE
Update DCOS CLI and enable debug

### DIFF
--- a/dcos_test_utils/dcos_cli.py
+++ b/dcos_test_utils/dcos_cli.py
@@ -18,8 +18,8 @@ import requests
 
 log = logging.getLogger(__name__)
 
-DCOS_CLI_URL = os.getenv('DCOS_CLI_URL', 'https://downloads.dcos.io/cli/releases/binaries/dcos/linux/x86-64/0.8.0/dcos')  # noqa: E501
-CORE_CLI_PLUGIN_URL = os.getenv('CORE_CLI_PLUGIN_URL', 'https://downloads.dcos.io/cli/releases/plugins/dcos-core-cli/linux/x86-64/dcos-core-cli-1.13-patch.4.zip')  # noqa: E501
+DCOS_CLI_URL = os.getenv('DCOS_CLI_URL', 'https://downloads.dcos.io/cli/releases/binaries/dcos/linux/x86-64/1.1.3/dcos')  # noqa: E501
+CORE_CLI_PLUGIN_URL = os.getenv('CORE_CLI_PLUGIN_URL', 'https://downloads.dcos.io/cli/releases/plugins/dcos-core-cli/linux/x86-64/dcos-core-cli-2.1-patch.1.zip')  # noqa: E501
 EE_CLI_PLUGIN_URL = os.getenv('EE_CLI_PLUGIN_URL', 'https://downloads.mesosphere.io/cli/releases/plugins/dcos-enterprise-cli/linux/x86-64/dcos-enterprise-cli-1.13-patch.0.zip')  # noqa: E501
 
 
@@ -155,14 +155,14 @@ class DcosCli:
             username = os.environ['DCOS_LOGIN_UNAME']
         if not password:
             password = os.environ['DCOS_LOGIN_PW']
-        self.exec_command(["dcos", "cluster", "setup", str(url), "--no-check", "--username={}".format(username),
+        self.exec_command(["dcos", "-vv", "cluster", "setup", str(url), "--no-check", "--username={}".format(username),
                            "--password={}".format(password)])
         if self.core_plugin_url:
-            self.exec_command(['dcos', 'plugin', 'add', '-u', self.core_plugin_url])
+            self.exec_command(['dcos', '-vv', 'plugin', 'add', '-u', self.core_plugin_url])
         if self.ee_plugin_url:
-            self.exec_command(['dcos', 'plugin', 'add', '-u', self.ee_plugin_url])
+            self.exec_command(['dcos', '-vv', 'plugin', 'add', '-u', self.ee_plugin_url])
         else:
-            self.exec_command(["dcos", "--debug", "package", "install", "dcos-enterprise-cli", "--cli", "--yes"])
+            self.exec_command(["dcos", "-vv", "--debug", "package", "install", "dcos-enterprise-cli", "--cli", "--yes"])
 
     def login_enterprise(self, username=None, password=None, provider=None):
         """ Authenticates the CLI with the setup Mesosphere Enterprise DC/OS cluster
@@ -179,7 +179,7 @@ class DcosCli:
         if not password:
             password = os.environ['DCOS_LOGIN_PW']
 
-        command = ["dcos", "auth", "login", "--username={}".format(username), "--password={}".format(password)]
+        command = ["dcos", "-vv", "auth", "login", "--username={}".format(username), "--password={}".format(password)]
         if provider:
             command.append("--provider={}".format(provider))
 
@@ -207,7 +207,7 @@ class DcosCliConfiguration:
         """
         try:
             stdout, _ = self.cli.exec_command(
-                ["dcos", "config", "show", key])
+                ["dcos", "-vv", "config", "show", key])
             return stdout.strip("\n ")
         except subprocess.CalledProcessError as e:
             if self.NOT_FOUND_MSG.format(key) in e.stderr.decode('utf-8'):
@@ -224,7 +224,7 @@ class DcosCliConfiguration:
         :type default: str
         """
         self.cli.exec_command(
-            ["dcos", "config", "set", name, value])
+            ["dcos", "-vv", "config", "set", name, value])
 
     def __getitem__(self, key: str):
         value = self.get(key)


### PR DESCRIPTION
## High-level description

Enable verbose output in dcos cli to debug issues with network.

## Corresponding DC/OS tickets (obligatory)

These JIRA ticket(s) must be updated (ideally closed) in the moment this PR lands:

  - Fixes: https://jira.d2iq.com/browse/D2IQ-69002


## Related tickets (optional)

Other tickets related to this change:

  - [DCOS-<number>](https://jira.mesosphere.com/browse/DCOS-<number>) Foo the Bar so it stops Bazzing.


## Related `dcos-launch` and `dcos` PRs

Is this change going to be propagated up into another repo? Test the change by bumping the `dcos-test-utils` SHA to point to these changes to test it. Link the corresponding PRs here:


## Checklist for all PRs

  - [ ] Included a test which will fail if code is reverted but test is not. If there is no test please explain here:
  - [ ] Include a test in `dcos-integration-tests` in https://github.com/dcos/dcos or explain why this is not applicable:
  - [ ] Include a test in https://github.com/dcos/dcos-launch or explain why this is not applicable:

[Integration tests](https://teamcity.mesosphere.io/project.html?projectId=DcosIo_DcosTestUtils) were run and

  - [ ] Integration Test - Enterprise (link to job: )
  - [ ] Integration Test - Open (link to job: )


**PLEASE FILL IN THE TEMPLATE ABOVE** / **DO NOT REMOVE ANY SECTIONS ABOVE THIS LINE**


## Instructions and review process

**What is the review process and when will my changes land?**

All PRs require 2 approvals using GitHub's [pull request reviews](https://help.github.com/articles/about-pull-request-reviews/).

Reviewers should be:
* Developers who understand the code being modified.
* Developers responsible for code that interacts with or depends on the code being modified.

It is best to proactively ask for 2 reviews by @mentioning the candidate reviewers in the PR comments area. The responsibility is on the developer submitting the PR to follow-up with reviewers and make sure a PR is reviewed in a timely manner.